### PR TITLE
Added capability restriction filter to plugin

### DIFF
--- a/safe-redirect-manager.php
+++ b/safe-redirect-manager.php
@@ -361,6 +361,17 @@ class SRM_Safe_Redirect_Manager {
 			'parent_item_colon' => '',
 			'menu_name' => __( 'Safe Redirect Manager', 'safe-redirect-manager' )
 		);
+		$this_capability = 'edit_posts';
+		$this_capability = apply_filters( 'safe_redirect_restrict_to_capability', $this_capability );
+		$capabilities = array(
+  							 	'edit_post'          => $this_capability,
+							    'read_post'          => $this_capability,
+							    'delete_post'        => $this_capability,
+							    'edit_posts'         => $this_capability,
+							    'edit_others_posts'  => $this_capability,
+							    'publish_posts'      => $this_capability,
+							    'read_private_posts' => $this_capability
+		);
 		$redirect_args = array(
 		  'labels' => $redirect_labels,
 		  'public' => false,
@@ -370,6 +381,7 @@ class SRM_Safe_Redirect_Manager {
 		  'query_var' => false,
 		  'rewrite' => false,
 		  'capability_type' => 'post',
+		  'capabilities' => $capabilities,
 		  'has_archive' => false, 
 		  'hierarchical' => false,
 		  'register_meta_box_cb' => array( $this, 'action_redirect_rule_metabox' ),


### PR DESCRIPTION
Any user that is author or better can access this plugin. 
Generally only admins or editors should be able to create redirects on the site.

I have added a filter "safe_redirect_restrict_to_capability", this will enable developers to restrict this plugin to users having that capability.
