### PR TITLE
Would be cool to use SRM methods in other plugins

### DIFF
--- a/safe-redirect-manager.php
+++ b/safe-redirect-manager.php
@@ -649,7 +649,7 @@ class SRM_Safe_Redirect_Manager {
 					$this->whitelist_hosts[] = $parsed_redirect['host'];
 					add_filter( 'allowed_redirect_hosts' , array( $this, 'filter_allowed_redirect_hosts' ) );
 				}
-					
+				
 				// if we have a valid status code, then redirect with it
 				if ( in_array( $status_code, $this->valid_status_codes ) )
 					wp_safe_redirect( esc_url_raw( $redirect_to ), $status_code );
@@ -713,4 +713,5 @@ class SRM_Safe_Redirect_Manager {
     	}
 }
 
-new SRM_Safe_Redirect_Manager();
+global $safe_redirect_manager;
+$safe_redirect_manager = new SRM_Safe_Redirect_Manager();


### PR DESCRIPTION
I recently wrote a quick, disposable importer plugin for SRM and needed to access the sanitise methods and meta key name properties. With the instantiation of the `SRM_Safe_Redirect_Manager` class not set to a var this wasn't possible. Here's a writeup: http://simonwheatley.co.uk/2012/09/safe-redirect-manager-import/

Might be handy if you considered this as a change.

Thanks!

Simon
