### PR TITLE
Fix possible undefined warning with parsed site url

### DIFF
--- a/safe-redirect-manager.php
+++ b/safe-redirect-manager.php
@@ -703,7 +703,7 @@ class SRM_Safe_Redirect_Manager {
 		 * the pre-WP path off the requested path.
 		 */
 		$parsed_site_url = parse_url( site_url() );
-		if ( '/' != $parsed_site_url['path'] ) {
+		if ( isset( $parsed_site_url['path'] ) && '/' != $parsed_site_url['path'] ) {
 			$requested_path = preg_replace( '@' . $parsed_site_url['path'] . '@i', '', $requested_path, 1 );
 		}
 		


### PR DESCRIPTION
If parse_url() does not return a path key, the check for the value of path can cause a warning in PHP.

Check to see that the path key exists before trying to compare it.

Fixes #21
