### PR TITLE
Allow filtering of redirects

### DIFF
--- a/safe-redirect-manager.php
+++ b/safe-redirect-manager.php
@@ -709,6 +709,10 @@ class SRM_Safe_Redirect_Manager {
 		
 		foreach ( $redirects as $redirect ) {
 			
+			// Allow redirects to be filtered
+			if ( ! $redirect = apply_filters( 'srm_filter_redirect_before_running', $redirect, $requested_path ) )
+				continue;
+
 			$redirect_from = untrailingslashit( $redirect['redirect_from'] );
 			if ( empty( $redirect_from ) )
 				$redirect_from = '/'; // this only happens in the case where there is a redirect on the root


### PR DESCRIPTION
- lines 712-715: Adds a filter around the $redirect to allow setting up redirect conditions programmatically. Allows you to do things like only redirect if the user is not an admin.. or only redirect on Tuesdays, or if the redirect is to '/about' and the user is registered, redirect somewhere else, etc

example: 

``` php
add_filter( 'srm_filter_redirect_before_running', 'dont_redirect_for_admin', 10, 2 );
function dont_redirect_for_admin( $redirect, $requested_path ) {

    if ( current_user_can('manage_options') && $requested_path == '/about/' )
        return false;

    return $redirect;
}
```
