### PR TITLE
Unslash the Request URI before matching

### DIFF
--- a/safe-redirect-manager.php
+++ b/safe-redirect-manager.php
@@ -67,6 +67,7 @@ class SRM_Safe_Redirect_Manager {
 		add_action( 'admin_print_styles-edit.php', array( $this, 'action_print_logo_css' ), 10, 1 );
 		add_action( 'admin_print_styles-post.php', array( $this, 'action_print_logo_css' ), 10, 1 );
 		add_action( 'admin_print_styles-post-new.php', array( $this, 'action_print_logo_css' ), 10, 1 );
+		add_filter( 'post_type_link', array( $this, 'filter_post_type_link' ), 10, 2  );
 
 		// Search filters
 		add_filter( 'posts_join', array( $this, 'filter_search_join' ) );
@@ -835,6 +836,26 @@ class SRM_Safe_Redirect_Manager {
 		$path = str_replace( '@', '', $path );
 
 		return $path;
+	}
+	
+	/**
+	 * Return a permalink for a redirect post, which is the "redirect from"
+	 * URL for that redirect.
+	 * 
+	 * @param string $permalink The permalink
+	 * @param object $post A Post object
+	 * @return string The permalink
+	 */
+	public function filter_post_type_link( $permalink, $post ) {
+		if ( 'redirect_rule' != $post->post_type )
+			return $permalink;
+		// We can't do anything to provide a permalink 
+		// for regex enabled redirects.
+		if ( get_post_meta( $post->ID, $this->meta_key_enable_redirect_from_regex, true ) )
+			return $permalink;
+		// Provide a permalink for the simple redirects
+		$redirect_from = get_post_meta( $post->ID, $this->meta_key_redirect_from, true );
+		return home_url( $redirect_from );
 	}
 }
 


### PR DESCRIPTION
Hi Taylor and co,

Here's another pull request for you. Those pesky slashes. :)

Cheers,

Simon

Commit notes:

Any single quotes, at least, in `$_SERVER['REQUEST_URI']` are slashed, unlash them before matching

This means you can redirect from a URL like http://example.com/because-he's-worth-it/ to the WordPress escaped version which would be http://example.com/because-he%27s-worth-it/
