### PR TITLE
Feature/create permalinks

### DIFF
--- a/safe-redirect-manager.php
+++ b/safe-redirect-manager.php
@@ -766,7 +766,8 @@ class SRM_Safe_Redirect_Manager {
 			return;
 
 		// get requested path and add a / before it
-		$requested_path = sanitize_text_field( $_SERVER['REQUEST_URI'] );
+		$requested_path = esc_url_raw( $_SERVER['REQUEST_URI'] );
+		$requested_path = stripslashes( $requested_path );
 
 		/**
 		 * If WordPress resides in a directory that is not the public root, we have to chop


### PR DESCRIPTION
See tlovett1/Safe-Redirect-Manager#30

This pull request implements a permalink creation for the "from" URL for simple redirects, so that static page caching plugins will be triggered to clear their caches.

Note that regex redirects cannot have permalinks created for them.
