### PR TITLE
Prevent redirects of: * to: /

### DIFF
--- a/safe-redirect-manager.php
+++ b/safe-redirect-manager.php
@@ -991,7 +991,7 @@ class SRM_Safe_Redirect_Manager {
 		foreach ( $messages as $id => $message ) :
 		?>
 			<div id="message" class="<?php echo esc_attr( $message[1] ); ?> fade">
-				<p class="<?php echo esc_attr( $id ); ?>"><?php echo $message[0]; ?></p>
+				<p class="<?php echo esc_attr( $id ); ?>"><?php echo esc_html( $message[0] ); ?></p>
 			</div>
 		<?php
 		endforeach;


### PR DESCRIPTION
It was possible for a user to set a redirect of "*" to "/", which caused an infinite loop. It was easy enough to update the metabox to check for this situation, but I discovered the main 'create redirect rule' screen was missing all of its input sanitisation.

This commit adds proper input sanitisation and whitelisting to action_save_post(), and utilises post meta to store any error messages we want to display to the user after the post has been saved. Unfortunately, I'm not aware of an action in WordPress that runs before save_post that would let us block the save and display a message to the
user.

I decided to add a new hook to the admin_notices action because these new messages are per-post, whereas the existing function dealt with per-site messages (e.g. "too many redirect rules").
