### PR TITLE
Don't redirect in wp-admin

### DIFF
--- a/safe-redirect-manager.php
+++ b/safe-redirect-manager.php
@@ -776,6 +776,10 @@ class SRM_Safe_Redirect_Manager {
 	 * @return void
 	 */
 	public function action_parse_request() {
+		
+		// Don't redirect from wp-admin
+		if ( is_admin() )
+			return;
 
 		// get redirects from cache or recreate it
 		if ( false === ( $redirects = get_transient( $this->cache_key_redirects ) ) ) {


### PR DESCRIPTION
Safe redirect manager shouldn't redirect when you're
in the admin. This fixes a bug where it was possible
to lock yourself out of wp-admin by creating a rogue
redirect rule.

From Automattic fork: https://github.com/Automattic/Safe-Redirect-Manager/commit/ceb3a86098fc5a1b0bad4293756a847eb6301753
