### PR TITLE
Duplicate GUIDs by default

### DIFF
--- a/safe-redirect-manager.php
+++ b/safe-redirect-manager.php
@@ -944,6 +944,11 @@ class SRM_Safe_Redirect_Manager {
 		if ( false !== strpos( $redirect_from, '*' ) )
 			return $permalink;
 
+		// Use default permalink if no $redirect_from exists - this prevents duplicate GUIDs
+		if ( empty( $redirect_from ) ) {
+			return $permalink;
+		}
+
 		return home_url( $redirect_from );
 	}
 }


### PR DESCRIPTION
All Safe-Redirect-Manager posts have matching GUIDs. I assume this is because the post type doesn't support 'title'. 

Aside from the philosophical ramifications of non-unique "unique IDs", this is problematic for my team because we use the <a href="http://crowdfavorite.com/ramp/">RAMP content deployment plugin</a> in our publishing workflow. RAMP relies on post GUIDs to determine whether a post exists on both staging and production. Posts with duplicate GUIDs are extremely problematic.

I've worked around the problem for now by generating a unique-ish GUID (using timestamp + author ID) in the filter_post_type_link function:

```
public function filter_post_type_link( $permalink, $post ) {
    if ( $this->redirect_post_type != $post->post_type )
        return $permalink;

    // Handle initial GUID generation
    if ('' == $post->post_name) 
     {
      return home_url('safe-redirect-rule-' . gmmktime() . '-' . $post->post_author);
    } 

    // We can't do anything to provide a permalink 
    // for regex enabled redirects.
    if ( get_post_meta( $post->ID, $this->meta_key_enable_redirect_from_regex, true ) )
        return $permalink;

    // We can't do anything if there is a wildcard in the redirect from
    $redirect_from = get_post_meta( $post->ID, $this->meta_key_redirect_from, true );
    if ( false !== strpos( $redirect_from, '*' ) )
        return $permalink;

    return home_url( $redirect_from );
  }
}
```
