### PR TITLE
Fixed redirecting only the root of a site

### DIFF
--- a/safe-redirect-manager.php
+++ b/safe-redirect-manager.php
@@ -794,6 +794,10 @@ class SRM_Safe_Redirect_Manager {
 		$requested_path = esc_url_raw( $_SERVER['REQUEST_URI'] );
 		$requested_path = stripslashes( $requested_path );
 
+		$requested_path_unslashed = untrailingslashit( $requested_path );
+		if ( empty( $requested_path_unslashed ) )
+			$requested_path_unslashed = '/';
+
 		/**
 		 * If WordPress resides in a directory that is not the public root, we have to chop
 		 * the pre-WP path off the requested path.
@@ -825,7 +829,7 @@ class SRM_Safe_Redirect_Manager {
 			if ( $enable_regex ) {
 				$matched_path = preg_match( '@' . $redirect_from . '@', $requested_path );
 			} else {
-				$matched_path = ( untrailingslashit( $requested_path ) == $redirect_from );
+				$matched_path = ( $requested_path_unslashed == $redirect_from );
 
 				// check if the redirect_from ends in a wildcard
 				if ( !$matched_path && (strrpos( $redirect_from, '*' ) === strlen( $redirect_from ) - 1) ) {


### PR DESCRIPTION
The designers wanted to redirect the root of the domain, but still have pages in the domain. But the way the code works, $request_path is unslashed and turns into "", but $redirect_from is unslashed and "" is replaced with a /. So a single "/" redirect never matches.

Thanks for Safe Redirect Manager, it's really simplified my life.
