### PR TITLE
Making _x translatable text work

### DIFF
--- a/safe-redirect-manager.php
+++ b/safe-redirect-manager.php
@@ -561,9 +561,9 @@ class SRM_Safe_Redirect_Manager {
 	 */
 	public function action_register_post_types() {
 		$redirect_labels = array(
-			'name' => _x( 'Safe Redirect Manager', 'post type general name' ),
-			'singular_name' => _x( 'Redirect', 'post type singular name' ),
-			'add_new' => _x( 'Create Redirect Rule', $this->redirect_post_type ),
+			'name' => _x( 'Safe Redirect Manager', 'post type general name', 'safe-redirect-manager' ),
+			'singular_name' => _x( 'Redirect', 'post type singular name', 'safe-redirect-manager' ),
+			'add_new' => _x( 'Create Redirect Rule', $this->redirect_post_type, 'safe-redirect-manager' ),
 			'add_new_item' => __( 'Safe Redirect Manager', 'safe-redirect-manager' ),
 			'edit_item' => __( 'Edit Redirect Rule', 'safe-redirect-manager' ),
 			'new_item' => __( 'New Redirect Rule', 'safe-redirect-manager' ),


### PR DESCRIPTION
Hi,

I've noticed that translatable text that uses _x does not seem to work correctly (for example, the "Create Redirect Rule" button).

What I did to fix this in my installation was:

1) Add the textdomain to the 3 _x translatable text (see pull request)

2) In the .po file the context (msgctxt) needs to be manually added if you're using POEdit as it doesn't seem to be able to extract it from source when the context is defined as  $this->redirect_post_type (so I manually had to add msgctxt "redirect_rule").

Hope it is helpful
