### PR TITLE
Check if the global $wp_query is null before using get_query_var....

### DIFF
--- a/safe-redirect-manager.php
+++ b/safe-redirect-manager.php
@@ -109,7 +109,7 @@ class SRM_Safe_Redirect_Manager {
 	public function filter_search_join( $join ) {
 		global $wp_query;
 
-		if ( is_null( $wp_query ) || $this->redirect_post_type != get_query_var( 'post_type' ) )
+		if ( empty( $wp_query ) || $this->redirect_post_type != get_query_var( 'post_type' ) )
 			return $join;
 
 		global $wpdb;
@@ -132,7 +132,7 @@ class SRM_Safe_Redirect_Manager {
 	public function filter_search_distinct( $distinct ) {
 		global $wp_query;
 
-		if ( is_null( $wp_query ) || $this->redirect_post_type != get_query_var( 'post_type' ) )
+		if ( empty( $wp_query ) || $this->redirect_post_type != get_query_var( 'post_type' ) )
 			return $distinct;
 
 		return 'DISTINCT';
@@ -149,7 +149,7 @@ class SRM_Safe_Redirect_Manager {
 	public function filter_search_where( $where ) {
 		global $wp_query;
 
-		if ( is_null( $wp_query ) || $this->redirect_post_type != get_query_var( 'post_type' ) || ! is_search() || empty( $where ) )
+		if ( empty( $wp_query ) || $this->redirect_post_type != get_query_var( 'post_type' ) || ! is_search() || empty( $where ) )
 			return $where;
 
 		$exact = get_query_var( 'exact' );


### PR DESCRIPTION
If wp_query is null, then get_query_var is trying to call $wp_query->get on a non-object, which causes a fatal error. 

Some plugins setup a new WP_Query on the 'plugins_loaded' action, which looking in wp-settings.php is called before the global $wp_query object is set up. In cases like this, the fatal error just makes the site die. 
