### PR TITLE
Redirects from '/' not working

### DIFF
--- a/safe-redirect-manager.php
+++ b/safe-redirect-manager.php
@@ -800,6 +800,11 @@ class SRM_Safe_Redirect_Manager {
 		$requested_path = esc_url_raw( $_SERVER['REQUEST_URI'] );
 		$requested_path = stripslashes( $requested_path );
 
+		$unslashed_requested_path = untrailingslashit( $requested_path );
+		if ( empty( $unslashed_requested_path ) ){
+			$unslashed_requested_path = '/';
+		}
+
 		/**
 		 * If WordPress resides in a directory that is not the public root, we have to chop
 		 * the pre-WP path off the requested path.
@@ -831,7 +836,7 @@ class SRM_Safe_Redirect_Manager {
 			if ( $enable_regex ) {
 				$matched_path = preg_match( '@' . $redirect_from . '@', $requested_path );
 			} else {
-				$matched_path = ( untrailingslashit( $requested_path ) == $redirect_from );
+				$matched_path = ( $unslashed_requested_path == $redirect_from );
 
 				// check if the redirect_from ends in a wildcard
 				if ( !$matched_path && (strrpos( $redirect_from, '*' ) === strlen( $redirect_from ) - 1) ) {


### PR DESCRIPTION
Right now redirects from '/' are not working unless regex is enabled. This bug goes back to untrailingslashit. We need to check for an empty path after removing the trailing slash from requested path like we do with redirect_from. If we have an empty path, we need to change it to '/'.

Tests in the feature/tests branch demonstrate this bug: https://github.com/tlovett1/Safe-Redirect-Manager/tree/bugfix/root-redirect-miss
