### PR TITLE
Added an extra validation to check if the redirect destination is valid.

### DIFF
--- a/safe-redirect-manager.php
+++ b/safe-redirect-manager.php
@@ -834,6 +834,10 @@ class SRM_Safe_Redirect_Manager {
             $status_code = $redirect['status_code'];
             $enable_regex = ( isset( $redirect['enable_regex'] ) ) ? $redirect['enable_regex'] : false;
 
+			// check if the redirection destination is valid, otherwise just skip it
+			if ( empty( $redirect_to ) )
+				continue;
+
             // check if requested path is the same as the redirect from path
             if ( $enable_regex ) {
                 $matched_path = preg_match( '@' . $redirect_from . '@' . $regex_flag, $requested_path );

--- a/safe-redirect-manager.php
+++ b/safe-redirect-manager.php
@@ -835,8 +835,8 @@ class SRM_Safe_Redirect_Manager {
             $enable_regex = ( isset( $redirect['enable_regex'] ) ) ? $redirect['enable_regex'] : false;
 
 			// check if the redirection destination is valid, otherwise just skip it
-			if ( empty( $redirect_to ) )
-				continue;
+	    if ( empty( $redirect_to ) )
+		continue;
 
             // check if requested path is the same as the redirect from path
             if ( $enable_regex ) {


### PR DESCRIPTION
This will validate the $redirect_to to check if it's not empty. Empty $redirect_to causes the page to exit without redirecting. With this validation, if a invalid redirect is found, we just skip it.

This happened while having a redirection without any field filled (no redirect to and no redirect from). The homepage was exiting to a blank page.