### PR TITLE
fixing undefined property notice for cap->delete_posts

### DIFF
--- a/safe-redirect-manager.php
+++ b/safe-redirect-manager.php
@@ -583,6 +583,7 @@ class SRM_Safe_Redirect_Manager {
             'edit_post' => $redirect_capability,
             'read_post' => $redirect_capability,
             'delete_post' => $redirect_capability,
+            'delete_posts' => $redirect_capability,
             'edit_posts' => $redirect_capability,
             'edit_others_posts' => $redirect_capability,
             'publish_posts' => $redirect_capability,


### PR DESCRIPTION
Fixing notice:

( ! ) Notice: Undefined property: stdClass::$delete_posts in .../wp-admin/includes/class-wp-posts-list-table.php on line 209