### PR TITLE
Trigger a CLI warning instead of an error on duplicate redirect 2: Electric Boogaloo

### DIFF
--- a/Dockunit.json
+++ b/Dockunit.json
@@ -4,7 +4,8 @@
 			"prettyName": "PHP-FPM 5.2",
 			"image": "tlovett1/php-5.2-phpunit-3.5",
 			"beforeScripts": [
-				"bash bin/install-wp-tests.sh wordpress_test234234 external external 192.168.50.4 4.1"
+				"service mysql start",
+				"bash bin/install-wp-tests.sh wordpress_test root '' localhost 4.1"
 			],
 			"testCommand": "phpunit"
 		},
@@ -12,7 +13,8 @@
 			"prettyName": "PHP-FPM 5.5",
 			"image": "tlovett1/php-fpm-phpunit-wp",
 			"beforeScripts": [
-				"bash bin/install-wp-tests.sh wordpress_testhey external external 192.168.50.4 4.1"
+				"service mysql start",
+				"bash bin/install-wp-tests.sh wordpress_test root '' localhost 4.1"
 			],
 			"testCommand": "phpunit"
 		}

--- a/Dockunit.json
+++ b/Dockunit.json
@@ -1,15 +1,6 @@
 {
 	"containers": [
 		{
-			"prettyName": "PHP-FPM 5.2",
-			"image": "tlovett1/php-5.2-phpunit-3.5",
-			"beforeScripts": [
-				"service mysql start",
-				"bash bin/install-wp-tests.sh wordpress_test root '' localhost 4.1"
-			],
-			"testCommand": "phpunit"
-		},
-		{
 			"prettyName": "PHP-FPM 5.5",
 			"image": "tlovett1/php-fpm-phpunit-wp",
 			"beforeScripts": [

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -25,7 +25,7 @@ install_wp() {
 		local ARCHIVE_NAME="wordpress-$WP_VERSION"
 	fi
 
-	wget -nv -O /tmp/wordpress.tar.gz http://wordpress.org/${ARCHIVE_NAME}.tar.gz --no-check-certificate
+	wget -nv -O /tmp/wordpress.tar.gz https://wordpress.org/${ARCHIVE_NAME}.tar.gz --no-check-certificate
 	tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR
 
 	wget -nv -O $WP_CORE_DIR/wp-content/db.php https://raw.github.com/markoheijnen/wp-mysqli/master/db.php --no-check-certificate
@@ -42,9 +42,9 @@ install_test_suite() {
 	# set up testing suite
 	mkdir -p $WP_TESTS_DIR
 	cd $WP_TESTS_DIR
-	svn co --quiet http://develop.svn.wordpress.org/trunk/tests/phpunit/includes/
+	svn co --quiet https://develop.svn.wordpress.org/trunk/tests/phpunit/includes/
 
-	wget -nv -O wp-tests-config.php http://develop.svn.wordpress.org/trunk/wp-tests-config-sample.php --no-check-certificate
+	wget -nv -O wp-tests-config.php https://develop.svn.wordpress.org/trunk/wp-tests-config-sample.php --no-check-certificate
 	sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR':" wp-tests-config.php
 	sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" wp-tests-config.php
 	sed $ioption "s/yourusernamehere/$DB_USER/" wp-tests-config.php

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: tlovett1, tollmanz, taylorde, 10up, jakemgold, danielbachhuber, Ve
 Tags: http redirects, redirect manager, url redirection, safe http redirection, multisite redirects
 Requires at least: 3.1
 Tested up to: 4.2
-Stable tag: 1.7.6
+Stable tag: 1.7.7
 
 Safely and easily manage your website's HTTP redirects.
 
@@ -23,6 +23,11 @@ Extract the zip file and just drop the contents in the wp-content/plugins/ direc
 2. This is the edit redirect page. Specify a "from" path, "to" path/URL, and a status code. You can schedule redirects for later dates just like posts.
 
 == Changelog ==
+
+= 1.7.7 (Jun. 18, 2015) =
+* Make default redirect status filterable
+* Add composer.json
+* Fix delete capability on redirect post type
 
 = 1.7.6 (Feb. 13, 2015) =
 * Use home_url() instead of site_url(). Props [swalkinshaw](https://github.com/swalkinshaw)

--- a/safe-redirect-manager.php
+++ b/safe-redirect-manager.php
@@ -1036,7 +1036,7 @@ class SRM_Safe_Redirect_Manager {
 			// import
 			$id = $this->create_redirect( $redirect_from, $redirect_to, $status_code, $regex );
 			if ( is_wp_error( $id ) ) {
-				$doing_wp_cli && WP_CLI::error( $id );
+				$doing_wp_cli && WP_CLI::warning( $id );
 				$skipped++;
 			} else {
 				$doing_wp_cli && WP_CLI::line( "Success - Created redirect from '{$redirect_from}' to '{$redirect_to}'" );

--- a/safe-redirect-manager.php
+++ b/safe-redirect-manager.php
@@ -4,7 +4,7 @@ Plugin Name: Safe Redirect Manager
 Plugin URI: http://www.10up.com
 Description: Easily and safely manage HTTP redirects.
 Author: Taylor Lovett (10up)
-Version: 1.7.6
+Version: 1.7.7
 Author URI: http://www.10up.com
 
 GNU General Public License, Free Software Foundation <http://creativecommons.org/licenses/GPL/2.0/>


### PR DESCRIPTION
Replaces the previous PR, #96, but uses "develop" as the base fork.

Additional commits that have been made to master have also been merged in.