### PR TITLE
Change the publicly_queryable property on the redirect_rule post type to false.

### DIFF
--- a/safe-redirect-manager.php
+++ b/safe-redirect-manager.php
@@ -600,7 +600,7 @@ class SRM_Safe_Redirect_Manager {
         $redirect_args = array(
             'labels' => $redirect_labels,
             'public' => false,
-            'publicly_queryable' => true,
+            'publicly_queryable' => false,
             'show_ui' => true,
             'show_in_menu' => 'tools.php',
             'query_var' => false,


### PR DESCRIPTION
As it stands now, querying a redirect_rule on the front-end will simply display a 404, rather than any sort of "if you weren't previewing this, you'd be redirected to X"-type message.

Setting this value to FALSE also removes the "Preview" button from the Publish meta box, which is determined by [`is_post_type_viewable()`](https://developer.wordpress.org/reference/functions/is_post_type_viewable/).