### PR TITLE
Update Travis-CI testing matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,15 @@ language: php
 php:
     - 5.3
     - 5.4
+    - 5.5
+    - 5.6
+    - 7.0
 
 env:
     - WP_VERSION=latest WP_MULTISITE=0
     - WP_VERSION=latest WP_MULTISITE=1
-    - WP_VERSION=3.8 WP_MULTISITE=0
-    - WP_VERSION=3.8 WP_MULTISITE=1
-    - WP_VERSION=3.7 WP_MULTISITE=0
-    - WP_VERSION=3.7 WP_MULTISITE=1
-    - WP_VERSION=3.6 WP_MULTISITE=0
-    - WP_VERSION=3.6 WP_MULTISITE=1
+    - WP_VERSION=4.4 WP_MULTISITE=0
+    - WP_VERSION=4.4 WP_MULTISITE=1
 
 before_script:
     - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION


### PR DESCRIPTION
Pushes of [perfectly-valid code were failing in Travis-CI](https://travis-ci.org/tlovett1/Safe-Redirect-Manager/builds/115675511), which is :crying_cat_face:.

Upon inspecting the Travis-CI logs, it appears that the WordPress test library has dropped support for older versions of WordPress Core by requiring the `WP_REST_SERVER` class (introduced in 4.4).

**Example output:**

``` bash
$ phpunit
Installing...
Running as single site... To run multisite, use -c tests/phpunit/multisite.xml
PHP Fatal error:  Class 'WP_REST_Server' not found in /tmp/wordpress-tests-lib/includes/spy-rest-server.php on line 3
PHP Stack trace:
PHP   1. {main}() /home/travis/.phpenv/versions/5.3.29/bin/phpunit:0
PHP   2. PHPUnit_TextUI_Command::main() /home/travis/.phpenv/versions/5.3.29/bin/phpunit:545
PHP   3. PHPUnit_TextUI_Command->run() phar:///home/travis/.phpenv/versions/5.3.29/bin/phpunit/phpunit/TextUI/Command.php:100
PHP   4. PHPUnit_TextUI_Command->handleArguments() phar:///home/travis/.phpenv/versions/5.3.29/bin/phpunit/phpunit/TextUI/Command.php:111
PHP   5. PHPUnit_TextUI_Command->handleBootstrap() phar:///home/travis/.phpenv/versions/5.3.29/bin/phpunit/phpunit/TextUI/Command.php:598
PHP   6. PHPUnit_Util_Fileloader::checkAndLoad() phar:///home/travis/.phpenv/versions/5.3.29/bin/phpunit/phpunit/TextUI/Command.php:779
PHP   7. PHPUnit_Util_Fileloader::load() phar:///home/travis/.phpenv/versions/5.3.29/bin/phpunit/phpunit/Util/Fileloader.php:38
PHP   8. include_once() phar:///home/travis/.phpenv/versions/5.3.29/bin/phpunit/phpunit/Util/Fileloader.php:56
PHP   9. require() /home/travis/build/tlovett1/Safe-Redirect-Manager/tests/bootstrap.php:17
PHP  10. require() /tmp/wordpress-tests-lib/includes/bootstrap.php:98
Fatal error: Class 'WP_REST_Server' not found in /tmp/wordpress-tests-lib/includes/spy-rest-server.php on line 3
```

This PR removes WordPress < 4.4 (where the REST API was introduced) from the Travis-CI testing matrix. I've also added checks for PHP 5.5, 5.6, and 7.0 so we're maintaining not only 5.3 compatibility but not breaking on more up-to-date systems.
