### PR TITLE
Clean up WP-CLI integration

### DIFF
--- a/inc/wp-cli.php
+++ b/inc/wp-cli.php
@@ -111,35 +111,57 @@ class Safe_Redirect_Manager_CLI extends WP_CLI_Command {
 	}
 
 	/**
-	 * Delete a redirect
+	 * Delete a redirect rule by its ID.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <id>
+	 * : The post ID for the redirect you wish to remove.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *   wp safe-redirect-manager delete 1
 	 *
 	 * @subcommand delete
 	 * @synopsis <id>
+	 *
+	 * @global $safe_redirect_manager
 	 */
 	public function delete( $args ) {
 		global $safe_redirect_manager;
 
-		$id = ( ! empty( $args[0] ) ) ? (int)$args[0] : 0;
+		$id = isset( $args['0'] ) ? (int) $args['0'] : 0;
 
-		$redirect = get_post( $id );
-		if ( ! $redirect || $safe_redirect_manager->redirect_post_type != $redirect->post_type )
-			WP_CLI::error( "{$id} isn't a valid redirect." );
+		// Verify that the post exists and is a redirect.
+		if ( $safe_redirect_manager->redirect_post_type !== get_post_type( $id ) ) {
+			return WP_CLI::error( sprintf(
+				__( 'Post ID #%d is not a valid redirect.', 'safe-redirect-manager' ),
+				$id
+			) );
+		}
 
+		// Remove the redirect and update the cache.
 		wp_delete_post( $id );
 		$safe_redirect_manager->update_redirect_cache();
-		WP_CLI::success( "Redirect #{$id} has been deleted." );
+
+		return WP_CLI::success( sprintf(
+			__( 'Redirect #%d has been deleted.', 'safe-redirect-manager' ),
+			$id
+		) );
 	}
 
 	/**
-	 * Update the redirect cache
+	 * Update the redirect cache.
 	 *
 	 * @subcommand update-cache
+	 *
+	 * @global $safe_redirect_manager
 	 */
 	public function update_cache() {
 		global $safe_redirect_manager;
 
 		$safe_redirect_manager->update_redirect_cache();
-		WP_CLI::success( "Redirect cache has been updated." );
+		WP_CLI::success( __( 'Redirect cache has been updated.', 'safe-redirect-manager' ) );
 	}
 
 	/**

--- a/inc/wp-cli.php
+++ b/inc/wp-cli.php
@@ -1,15 +1,17 @@
 <?php
 /**
- * wp-cli integration
+ * WP-CLI integration.
  */
 
 WP_CLI::add_command( 'safe-redirect-manager', 'Safe_Redirect_Manager_CLI' );
 
+/**
+ * Manage redirects via Safe Redirect Manager.
+ */
 class Safe_Redirect_Manager_CLI extends WP_CLI_Command {
 
-
 	/**
-	 * List all of the currently configured redirects
+	 * List the current redirect rules.
 	 *
 	 * @subcommand list
 	 */


### PR DESCRIPTION
There are admittedly several small things going on in this PR:

1. **Rewrite the `create()` method:** Previously, the HTTP status code, regex mode, and post_status were passed as positional arguments. This refactors them to be **associative**, using the `--status-code=<code>`, `--regex`, and `post-status=<status>` options, respectively.
2. Improve DocBlocks for the "create" and "delete" commands, ensuring that WP-CLI can generate useful documentation when passed the `--help` flag.
3. Minor refactoring of the `delete()` method to simplify the checks and provide clearer feedback.
4. Properly prepare more strings for translation.