### PR TITLE
Changed no_found_rows to true for performance benefits

### DIFF
--- a/safe-redirect-manager.php
+++ b/safe-redirect-manager.php
@@ -726,7 +726,7 @@ class SRM_Safe_Redirect_Manager {
 
             // Some arguments that don't need to be configurable
             $query_args['post_type'] = $this->redirect_post_type;
-            $query_args['no_found_rows'] = false;
+            $query_args['no_found_rows'] = true;
             $query_args['update_term_cache'] = false;
 
             $redirect_query = new WP_Query( $query_args );


### PR DESCRIPTION
$query_args['no_found_rows'] was set to false, so WP calculates and returns total numer of rows. However that information was never used. Setting no_found_rows to true is more performant and is recommended.
