### PR TITLE
Adds a custom capability

### DIFF
--- a/safe-redirect-manager.php
+++ b/safe-redirect-manager.php
@@ -577,7 +577,15 @@ class SRM_Safe_Redirect_Manager {
             'parent_item_colon' => '',
             'menu_name' => __( 'Safe Redirect Manager', 'safe-redirect-manager' )
         );
-        $redirect_capability = 'manage_options';
+	$redirect_capability = 'manage_safe_redirects';
+	$roles = array( 'administrator');
+	foreach ( $roles as $role ) {
+		$role = get_role( $role );
+		if ( empty( $role ) ) {
+			continue;
+		}
+		$role->add_cap( $redirect_capability );
+	}
         $redirect_capability = apply_filters( 'srm_restrict_to_capability', $redirect_capability );
         $capabilities = array(
             'edit_post' => $redirect_capability,

--- a/safe-redirect-manager.php
+++ b/safe-redirect-manager.php
@@ -577,15 +577,15 @@ class SRM_Safe_Redirect_Manager {
             'parent_item_colon' => '',
             'menu_name' => __( 'Safe Redirect Manager', 'safe-redirect-manager' )
         );
-	$redirect_capability = 'manage_safe_redirects';
-	$roles = array( 'administrator');
-	foreach ( $roles as $role ) {
-		$role = get_role( $role );
-		if ( empty( $role ) ) {
-			continue;
-		}
-		$role->add_cap( $redirect_capability );
-	}
+        $redirect_capability = 'manage_safe_redirects';
+        $roles = array( 'administrator');
+        foreach ( $roles as $role ) {
+             $role = get_role( $role );
+             if ( empty( $role ) ) {
+                  continue;
+            }
+            $role->add_cap( $redirect_capability );
+        }
         $redirect_capability = apply_filters( 'srm_restrict_to_capability', $redirect_capability );
         $capabilities = array(
             'edit_post' => $redirect_capability,


### PR DESCRIPTION
Adds a custom capability (instead of using "manage_options") and assigns it to the Administrator Role (the only default wordpress role that has the "manage_options" capability).  This allows role manager plugins to add the capability of "manage_safe_redirects" to other default and custom wordpress roles without giving those roles other features assigned to the "manage_options" role (such as "Tools > Delete Site" in multisite installations)