### PR TITLE
Use menu_order to set order of redirect processing

### DIFF
--- a/inc/classes/class-srm-post-type.php
+++ b/inc/classes/class-srm-post-type.php
@@ -27,6 +27,7 @@ class SRM_Post_Type {
 		add_action( 'init', array( $this, 'action_register_post_types' ) );
 		add_action( 'save_post', array( $this, 'action_save_post' ) );
 		add_filter( 'manage_redirect_rule_posts_columns', array( $this, 'filter_redirect_columns' ) );
+		add_filter( 'manage_edit-redirect_rule_sortable_columns', array( $this, 'filter_redirect_sortable_columns' ) );
 		add_action( 'manage_redirect_rule_posts_custom_column', array( $this, 'action_custom_redirect_columns' ), 10, 2 );
 		add_action( 'transition_post_status', array( $this, 'action_transition_post_status' ), 10, 3 );
 		add_filter( 'post_updated_messages', array( $this, 'filter_redirect_updated_messages' ) );
@@ -347,7 +348,10 @@ class SRM_Post_Type {
 			echo esc_html( get_post_meta( $post_id, '_redirect_rule_to', true ) );
 		} elseif ( 'srm_redirect_rule_status_code' === $column ) {
 			echo absint( get_post_meta( $post_id, '_redirect_rule_status_code', true ) );
-		}
+		} elseif ( 'menu_order' == $column ) {
+			global $post;
+			echo $post->menu_order;
+ 		}
 	}
 
 	/**
@@ -360,6 +364,7 @@ class SRM_Post_Type {
 	public function filter_redirect_columns( $columns ) {
 		$columns['srm_redirect_rule_to']          = esc_html__( 'Redirect To', 'safe-redirect-manager' );
 		$columns['srm_redirect_rule_status_code'] = esc_html__( 'HTTP Status Code', 'safe-redirect-manager' );
+		$columns[ 'menu_order'] 									= esc_html__( 'Order', 'safe-redirect-manager' );
 
 		// Change the title column
 		$columns['title'] = esc_html__( 'Redirect From', 'safe-redirect-manager' );
@@ -368,6 +373,17 @@ class SRM_Post_Type {
 		unset( $columns['date'] );
 		$columns['date'] = esc_html__( 'Date', 'safe-redirect-manager' );
 
+		return $columns;
+	}
+
+	/**
+	 * Allow menu_order column to be sortable.
+	 *
+	 * @param $columns
+	 * @return mixed
+	 */
+	public function filter_redirect_sortable_columns( $columns ) {
+		$columns['menu_order'] = 'menu_order';
 		return $columns;
 	}
 
@@ -487,7 +503,7 @@ class SRM_Post_Type {
 			'hierarchical'         => false,
 			'register_meta_box_cb' => array( $this, 'action_redirect_rule_metabox' ),
 			'menu_position'        => 80,
-			'supports'             => array( '' ),
+			'supports'             => array( 'page-attributes' ),
 		);
 		register_post_type( 'redirect_rule', $redirect_args );
 	}

--- a/inc/classes/class-srm-wp-cli.php
+++ b/inc/classes/class-srm-wp-cli.php
@@ -189,12 +189,12 @@ class SRM_WP_CLI extends WP_CLI_Command {
 	 * redirection from and to URLs, regex flag and HTTP redirection code. Here
 	 * is example table:
 	 *
-	 * | source                     | target             | regex | code |
-	 * |----------------------------|--------------------|-------|------|
-	 * | /legacy-url                | /new-url           | 0     | 301  |
-	 * | /category-1                | /new-category-slug | 0     | 302  |
-	 * | /tes?t/[0-9]+/path/[^/]+/? | /go/here           | 1     | 302  |
-	 * | ...                        | ...                | ...   | ...  |
+	 * | source                     | target             | regex | code | order |
+	 * |----------------------------|--------------------|-------|------|-------|
+	 * | /legacy-url                | /new-url           | 0     | 301  | 0     |
+	 * | /category-1                | /new-category-slug | 0     | 302  | 1     |
+	 * | /tes?t/[0-9]+/path/[^/]+/? | /go/here           | 1     | 302  | 3     |
+	 * | ...                        | ...                | ...   | ...  | ...   |
 	 *
 	 * You can also use exported redirects from "Redirection" plugin, which you
 	 * can download here: /wp-admin/tools.php?page=redirection.php&sub=modules
@@ -211,11 +211,15 @@ class SRM_WP_CLI extends WP_CLI_Command {
 	 * <code-column>
 	 * : Header title for code column mapping.
 	 *
+	 * <order-column>
+	 * : Header title for order column mapping.
+	 *
+	 *
 	 * ## EXAMPLE
 	 *
 	 *     wp safe-redirect-manager import redirections.csv
 	 *
-	 * @synopsis <file> [--source=<source-column>] [--target=<target-column>] [--regex=<regex-column>] [--code=<code-column>]
+	 * @synopsis <file> [--source=<source-column>] [--target=<target-column>] [--regex=<regex-column>] [--code=<code-column>]  [--order=<order-column>]
 	 *
 	 * @since 1.7.6
 	 *

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -31,6 +31,7 @@ function srm_get_redirects( $args = array(), $hard = false ) {
 				'paged'          => $i,
 				'fields'         => 'ids',
 				'orderby'        => 'menu_order',
+				'order'          => 'ASC',
 			);
 
 			$query_args = array_merge( $defaults, $args );
@@ -322,7 +323,7 @@ function srm_import_file( $file, $args ) {
 		$redirect_to   = srm_sanitize_redirect_to( $rule[ $args['target'] ] );
 		$status_code   = ! empty( $rule[ $args['code'] ] ) ? $rule[ $args['code'] ] : 302;
 		$regex         = ! empty( $rule[ $args['regex'] ] ) ? filter_var( $rule[ $args['regex'] ], FILTER_VALIDATE_BOOLEAN ) : false;
-		$menu_order 	= ! empty( $rule[ $args['order'] ] ) ? $rule[ $args['order'] ] : 0;
+		$menu_order 	 = ! empty( $rule[ $args['order'] ] ) ? $rule[ $args['order'] ] : 0;
 
 		// import
 		$id = srm_create_redirect( $redirect_from, $redirect_to, $status_code, $regex, 'publish', $menu_order );

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -30,7 +30,7 @@ function srm_get_redirects( $args = array(), $hard = false ) {
 				'post_status'    => 'publish',
 				'paged'          => $i,
 				'fields'         => 'ids',
-				'orderby'        => 'menu_order',
+				'orderby'        => 'menu_order ID',
 				'order'          => 'ASC',
 			);
 

--- a/tests/test-core.php
+++ b/tests/test-core.php
@@ -474,11 +474,11 @@ class SRMTestCore extends WP_UnitTestCase {
 
 		$redirects = array(
 			// headers
-			array( 'http code', 'legacy url', 'new url', 'is_regex' ),
+			array( 'http code', 'legacy url', 'new url', 'is_regex', 'order' ),
 			// redirects
-			array( 302, '/some-url', '/new-url', 0 ),
-			array( 301, '/broken-url', '/fixed-url', 0 ),
-			array( 301, '/reg?ex/\d+/path', '/go/here', 1 ),
+			array( 302, '/some-url', '/new-url', 0, 0 ),
+			array( 301, '/broken-url', '/fixed-url', 0, 0 ),
+			array( 301, '/reg?ex/\d+/path', '/go/here', 1, 0 ),
 		);
 
 		foreach ( $redirects as $row ) {
@@ -493,6 +493,7 @@ class SRMTestCore extends WP_UnitTestCase {
 				'target' => 'new url',
 				'regex'  => 'is_regex',
 				'code'   => 'http code',
+				'order'  => 'order'
 			)
 		);
 


### PR DESCRIPTION
Uses the menu_order value to sort the redirects to give more control over the order they are processed in.

Adds ability to import the menu order when creating redirects from a file via wp-cli.