### PR TITLE
remove query string from request path

### DIFF
--- a/inc/classes/class-srm-redirect.php
+++ b/inc/classes/class-srm-redirect.php
@@ -57,7 +57,7 @@ class SRM_Redirect {
 		}
 
 		// get requested path and add a / before it
-		$requested_path = esc_url_raw( $_SERVER['REQUEST_URI'] );
+		$requested_path = esc_url_raw( parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH ) );
 		$requested_path = untrailingslashit( stripslashes( $requested_path ) );
 
 		/**


### PR DESCRIPTION
It was brought to my attention that this plugin doesn't strip off the query vars when doing the URL comparison.  This issue came up with regard to utm query parameters, but the issue applies to all query parameters.

I think this is a pretty straightforward approach, but I'm definitely open to discussion.  It's possible that this is the intention here, as I realize that maybe users are creating regex strings that include matches on specific query vars.  If so, then an alternative suggestion would be to add a call to apply_filters() on $requested_path so that we could handle this change in our theme code.