### PR TITLE
Add filters for request path and redirect path

### DIFF
--- a/inc/classes/class-srm-redirect.php
+++ b/inc/classes/class-srm-redirect.php
@@ -57,7 +57,7 @@ class SRM_Redirect {
 		}
 
 		// get requested path and add a / before it
-		$requested_path = esc_url_raw( $_SERVER['REQUEST_URI'] );
+		$requested_path = esc_url_raw( apply_filters( 'srm_requested_path', $_SERVER['REQUEST_URI'] ) );
 		$requested_path = untrailingslashit( stripslashes( $requested_path ) );
 
 		/**
@@ -151,7 +151,7 @@ class SRM_Redirect {
 					$redirect_to = preg_replace( '@' . $redirect_from . '@' . $regex_flag, $redirect_to, $requested_path );
 				}
 
-				$sanitized_redirect_to = esc_url_raw( $redirect_to );
+				$sanitized_redirect_to = esc_url_raw( apply_filters( 'srm_redirect_to', $redirect_to ) );
 
 				do_action( 'srm_do_redirect', $requested_path, $sanitized_redirect_to, $status_code );
 


### PR DESCRIPTION
Any interest in adding filters in these two places for added flexibility?

My particular use case for these filters is to strip off the query string from the requested path, so that the match is done on the path only.  And then I'm adding the query string back on to the redirected URI, so that we don't lose the tracking information provided by the query vars.  If there's demand for those changes in particular, I could open a new PR for that, although I see that as an optional feature, given that some users may be intentionally matching on query vars.

