### PR TITLE
Bootstrap in 1 place, not all files

### DIFF
--- a/inc/classes/class-srm-post-type.php
+++ b/inc/classes/class-srm-post-type.php
@@ -602,4 +602,3 @@ class SRM_Post_Type {
 	}
 }
 
-SRM_Post_Type::factory();

--- a/inc/classes/class-srm-redirect.php
+++ b/inc/classes/class-srm-redirect.php
@@ -192,4 +192,3 @@ class SRM_Redirect {
 	}
 }
 
-SRM_Redirect::factory();

--- a/inc/classes/class-srm-wp-cli.php
+++ b/inc/classes/class-srm-wp-cli.php
@@ -248,5 +248,3 @@ class SRM_WP_CLI extends WP_CLI_Command {
 		WP_CLI::success( "All done! {$created} redirects were imported, {$skipped} were skipped" );
 	}
 }
-
-WP_CLI::add_command( 'safe-redirect-manager', 'SRM_WP_CLI' );

--- a/safe-redirect-manager.php
+++ b/safe-redirect-manager.php
@@ -29,4 +29,8 @@ require_once( dirname( __FILE__ ) . '/inc/classes/class-srm-redirect.php' );
 
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	require_once( dirname( __FILE__ ) . '/inc/classes/class-srm-wp-cli.php' );
+	WP_CLI::add_command( 'safe-redirect-manager', 'SRM_WP_CLI' );
 }
+
+SRM_Post_Type::factory();
+SRM_Redirect::factory();


### PR DESCRIPTION
its not possible to load the classes without also booting them up and running them, this commit fixes that by moving the initial instantiation into the plugin root file, now all bootstrapping is done in a single place

As a result, the tests should become a little more reliable as the global state is curtailed a little. Ideally there would be no `factory` static method or need for singletons. If you only need 1 of the object, just create 1 of them and pass the object around