### PR TITLE
Extracts redirect matching logic to its own match_redirect method.

### DIFF
--- a/inc/classes/class-srm-redirect.php
+++ b/inc/classes/class-srm-redirect.php
@@ -51,27 +51,19 @@ class SRM_Redirect {
 	}
 
 	/**
-	 * Check current url against redirects
+	 * Matches a redirect given a path.
 	 *
-	 * @since 1.8
+	 * @param string $requested_path The path to check redirects for.
+	 *
+	 * @return array|bool The redirect url. False if no redirect is found.
 	 */
-	public function maybe_redirect() {
-
-		// Don't redirect unless not on admin. If 404 filter enabled, require query is a 404.
-		if ( is_admin() || ( apply_filters( 'srm_redirect_only_on_404', false ) && ! is_404() ) ) {
-			return;
-		}
-
+	public function match_redirect( $requested_path ) {
 		$redirects = srm_get_redirects();
 
 		// If we have no redirects, there is no need to continue
 		if ( empty( $redirects ) ) {
-			return;
+			return false;
 		}
-
-		// get requested path and add a / before it
-		$requested_path = esc_url_raw( apply_filters( 'srm_requested_path', $_SERVER['REQUEST_URI'] ) );
-		$requested_path = untrailingslashit( stripslashes( $requested_path ) );
 
 		/**
 		 * If WordPress resides in a directory that is not the public root, we have to chop
@@ -169,24 +161,58 @@ class SRM_Redirect {
 
 				$sanitized_redirect_to = esc_url_raw( apply_filters( 'srm_redirect_to', $redirect_to ) );
 
-				do_action( 'srm_do_redirect', $requested_path, $sanitized_redirect_to, $status_code );
-
-				if ( defined( 'PHPUNIT_SRM_TESTSUITE' ) && PHPUNIT_SRM_TESTSUITE ) {
-					// Don't actually redirect if we are testing
-					return;
-				}
-
-				header( 'X-Safe-Redirect-Manager: true' );
-
-				// if we have a valid status code, then redirect with it
-				if ( in_array( $status_code, srm_get_valid_status_codes(), true ) ) {
-					wp_safe_redirect( $sanitized_redirect_to, $status_code );
-				} else {
-					wp_safe_redirect( $sanitized_redirect_to );
-				}
-
-				exit;
+				return [
+					'redirect_to'  => $sanitized_redirect_to,
+					'status_code'  => $status_code,
+					'enable_regex' => $enable_regex,
+				];
 			}
+
+			return false;
+		}
+	}
+
+	/**
+	 * Check current url against redirects
+	 *
+	 * @since 1.8
+	 */
+	public function maybe_redirect() {
+
+		// Don't redirect unless not on admin. If 404 filter enabled, require query is a 404.
+		if ( is_admin() || ( apply_filters( 'srm_redirect_only_on_404', false ) && ! is_404() ) ) {
+			return;
+		}
+
+		// get requested path and add a / before it
+		$requested_path = esc_url_raw( apply_filters( 'srm_requested_path', $_SERVER['REQUEST_URI'] ) );
+		$requested_path = untrailingslashit( stripslashes( $requested_path ) );
+
+		$matched_redirect = $this->match_redirect( $requested_path );
+
+		if ( $matched_redirect ) {
+			do_action(
+				'srm_do_redirect',
+				$requested_path,
+				$matched_redirect['redirect_to'],
+				$matched_redirect['status_code']
+			);
+
+			if ( defined( 'PHPUNIT_SRM_TESTSUITE' ) && PHPUNIT_SRM_TESTSUITE ) {
+				// Don't actually redirect if we are testing
+				return;
+			}
+
+			header( 'X-Safe-Redirect-Manager: true' );
+
+			// if we have a valid status code, then redirect with it
+			if ( in_array( $matched_redirect['status_code'], srm_get_valid_status_codes(), true ) ) {
+				wp_safe_redirect( $matched_redirect['redirect_to'], $matched_redirect['status_code'] );
+			} else {
+				wp_safe_redirect( $matched_redirect['redirect_to'] );
+			}
+
+			exit;
 		}
 	}
 

--- a/inc/classes/class-srm-redirect.php
+++ b/inc/classes/class-srm-redirect.php
@@ -190,30 +190,32 @@ class SRM_Redirect {
 
 		$matched_redirect = $this->match_redirect( $requested_path );
 
-		if ( $matched_redirect ) {
-			do_action(
-				'srm_do_redirect',
-				$requested_path,
-				$matched_redirect['redirect_to'],
-				$matched_redirect['status_code']
-			);
-
-			if ( defined( 'PHPUNIT_SRM_TESTSUITE' ) && PHPUNIT_SRM_TESTSUITE ) {
-				// Don't actually redirect if we are testing
-				return;
-			}
-
-			header( 'X-Safe-Redirect-Manager: true' );
-
-			// if we have a valid status code, then redirect with it
-			if ( in_array( $matched_redirect['status_code'], srm_get_valid_status_codes(), true ) ) {
-				wp_safe_redirect( $matched_redirect['redirect_to'], $matched_redirect['status_code'] );
-			} else {
-				wp_safe_redirect( $matched_redirect['redirect_to'] );
-			}
-
-			exit;
+		if ( empty( $matched_redirect ) ) {
+			return;
 		}
+
+		do_action(
+			'srm_do_redirect',
+			$requested_path,
+			$matched_redirect['redirect_to'],
+			$matched_redirect['status_code']
+		);
+
+		if ( defined( 'PHPUNIT_SRM_TESTSUITE' ) && PHPUNIT_SRM_TESTSUITE ) {
+			// Don't actually redirect if we are testing
+			return;
+		}
+
+		header( 'X-Safe-Redirect-Manager: true' );
+
+		// if we have a valid status code, then redirect with it
+		if ( in_array( $matched_redirect['status_code'], srm_get_valid_status_codes(), true ) ) {
+			wp_safe_redirect( $matched_redirect['redirect_to'], $matched_redirect['status_code'] );
+		} else {
+			wp_safe_redirect( $matched_redirect['redirect_to'] );
+		}
+
+		exit;
 	}
 
 	/**

--- a/inc/classes/class-srm-redirect.php
+++ b/inc/classes/class-srm-redirect.php
@@ -167,9 +167,9 @@ class SRM_Redirect {
 					'enable_regex' => $enable_regex,
 				];
 			}
-
-			return false;
 		}
+
+		return false;
 	}
 
 	/**

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -366,3 +366,20 @@ function srm_import_file( $file, $args ) {
 		'skipped' => $skipped,
 	);
 }
+
+/**
+ * Tries to match a redirect given a path. Return the redirect array or false on failure.
+ *
+ * @param string $path The path to check redirects for.
+ *
+ * @return array|bool {
+ * 	Redirect array config.
+ *
+ * 	@type string	$redirect_to	The redirect to url.
+ * 	@type int		$status_code	The redirect status code.
+ * 	@type bool		$enable_regex	Whether this redirect has regex enabled or not.
+ * }
+ */
+function srm_match_redirect( $path ) {
+	return SRM_Redirect::factory()->match_redirect( $path );
+}

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -373,11 +373,11 @@ function srm_import_file( $file, $args ) {
  * @param string $path The path to check redirects for.
  *
  * @return array|bool {
- * 	Redirect array config.
+ *  Redirect array config.
  *
- * 	@type string	$redirect_to	The redirect to url.
- * 	@type int		$status_code	The redirect status code.
- * 	@type bool		$enable_regex	Whether this redirect has regex enabled or not.
+ *  @type string    $redirect_to    The redirect to url.
+ *  @type int       $status_code    The redirect status code.
+ *  @type bool      $enable_regex   Whether this redirect has regex enabled or not.
  * }
  */
 function srm_match_redirect( $path ) {

--- a/tests/php/test-core.php
+++ b/tests/php/test-core.php
@@ -586,4 +586,23 @@ class SRMTestCore extends WP_UnitTestCase {
 		SRM_Redirect::factory()->maybe_redirect();
 		$this->assertFalse( $redirected, 'Expected that /noredirect/ would not redirect, but instead redirected to ' . $redirect_to );
 	}
+
+	/**
+	 * Tests the match redirect function
+	 *
+	 */
+	public function testMatchRedirect() {
+		$redirect_to            = '/gohere';
+		srm_create_redirect( '/', $redirect_to );
+
+		$matched_redirect = srm_match_redirect( '/' );
+
+		$this->assertTrue( $matched_redirect['redirect_to'] === $redirect_to );
+
+		srm_create_redirect( '/one-page', $redirect_to );
+
+		$matched_redirect = srm_match_redirect( '/one-page' );
+
+		$this->assertTrue( $matched_redirect['redirect_to'] === $redirect_to );
+	}
 }


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
Introduces a new `match_redirect` method and updates `maybe_redirect` to use this new method.

It also introduces a `srm_match_redirect` function to expose matching redirect logic to themes and plugins.

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Alternate Designs
See https://github.com/10up/safe-redirect-manager/issues/197
<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits
Code is more testable now and maybe_redirect now only does one thing.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
None
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
Manual testing
<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected? 
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
