### PR TITLE
fix line break issues in readme.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tested up to: 5.3
 Stable tag: 1.9.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
- 
+
 Safely and easily manage your website's HTTP redirects.
 
 == Description ==
@@ -26,32 +26,22 @@ There are no overarching settings for this plugin. To manage redirects, navigate
 Each redirect contains a few fields that you can utilize:
 
 === "Redirect From" ===
-This should be a path relative to the root of your WordPress installation. When someone visits your site with a path
-that matches this one, a redirect will occur. If your site is located at `http://example.com/wp/` and you wanted to redirect `http://example.com/wp/about` to `http://example.com`, your "Redirect From" would be `/about`.
+This should be a path relative to the root of your WordPress installation. When someone visits your site with a path that matches this one, a redirect will occur. If your site is located at `http://example.com/wp/` and you wanted to redirect `http://example.com/wp/about` to `http://example.com`, your "Redirect From" would be `/about`.
 
-Clicking the "Enable Regex" checkbox allows you to use regular expressions in your path. There are many
-[great tutorials](http://www.regular-expressions.info) on regular expressions.
+Clicking the "Enable Regex" checkbox allows you to use regular expressions in your path. There are many [great tutorials](http://www.regular-expressions.info) on regular expressions.
 
-You can also use wildcards in your "Redirect From" paths. By adding an `*` at the end of a URL, your redirect will
-match any request that starts with your "Redirect From". Wildcards support replacements. This means if you have a
-wildcard in your from path that matches a string, you can have that string replace a wildcard character in your
-"Redirect To" path. For example, if your "Redirect From" is `/test/*`, your "Redirect To" is
-`http://google.com/*`, and the requested path is `/test/string`, the user would be redirect to `http://google.com/string`.
+You can also use wildcards in your "Redirect From" paths. By adding an `*` at the end of a URL, your redirect will match any request that starts with your "Redirect From". Wildcards support replacements. This means if you have a wildcard in your from path that matches a string, you can have that string replace a wildcard character in your "Redirect To" path. For example, if your "Redirect From" is `/test/*`, your "Redirect To" is `http://google.com/*`, and the requested path is `/test/string`, the user would be redirect to `http://google.com/string`.
 
 === "Redirect To" ===
-This should be a path (i.e. `/test`) or a URL (i.e. `http://example.com/wp/test`). If a requested path matches
-"Redirect From", they will be redirected here. "Redirect To" supports wildcard and regular expression replacements.
+This should be a path (i.e. `/test`) or a URL (i.e. `http://example.com/wp/test`). If a requested path matches "Redirect From", they will be redirected here. "Redirect To" supports wildcard and regular expression replacements.
 
 === "HTTP Status Code" ===
-[HTTP status codes](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html) are numbers that contain information about
-a request (i.e. whether it was successful, unauthorized, not found, etc). You should almost always use either 302 (temporarily moved) or 301 (permanently moved).
+[HTTP status codes](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html) are numbers that contain information about a request (i.e. whether it was successful, unauthorized, not found, etc). You should almost always use either 302 (temporarily moved) or 301 (permanently moved).
 
 *Note:*
 
-* Redirects are cached using the Transients API. Cache busts occur when redirects are added, updated, and deleted
-so you shouldn't be serving stale redirects.
-* By default the plugin only allows at most 250 redirects to prevent performance issues. There is a filter
-`srm_max_redirects` that you can utilize to up this number.
+* Redirects are cached using the Transients API. Cache busts occur when redirects are added, updated, and deleted so you shouldn't be serving stale redirects.
+* By default the plugin only allows at most 250 redirects to prevent performance issues. There is a filter `srm_max_redirects` that you can utilize to up this number.
 * "Redirect From" and requested paths are case insensitive by default.
 
 == Changelog ==


### PR DESCRIPTION
Co-Authored-By: David Greenwald <david@davidgreenwald.com>

<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

@davidegreenwald noticed odd display issues on wp.org, this PR removes some odd line breaks in our readme.txt to ensure we properly display our readme text on dotorg.

### Alternate Designs

n/a

### Benefits

ensure we properly display our readme text on dotorg

### Possible Drawbacks

none identified

### Verification Process

Validated text on wpreadme.com

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

n/a

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
```
### Fixed
- Readme display issue on WordPress.org (props @davidegreenwald)
```