### PR TITLE
Bugfix: Issue 208 wildcard redirects

### DIFF
--- a/inc/classes/class-srm-redirect.php
+++ b/inc/classes/class-srm-redirect.php
@@ -128,11 +128,8 @@ class SRM_Redirect {
 				if ( ! $matched_path && ( strrpos( $redirect_from, '*' ) === strlen( $redirect_from ) - 1 ) ) {
 					$wildcard_base = substr( $redirect_from, 0, strlen( $redirect_from ) - 1 );
 
-					// Remove the trailing slash from the wildcard base, matching removal from request path.
-					$wildcard_base = untrailingslashit( $wildcard_base );
-
 					// Mark as path match if requested path matches the base of the redirect from.
-					$matched_path = ( substr( $normalized_requested_path, 0, strlen( $wildcard_base ) ) === $wildcard_base );
+					$matched_path = ( substr( trailingslashit( $normalized_requested_path ), 0, strlen( $wildcard_base ) ) === $wildcard_base );
 					if ( ( strrpos( $redirect_to, '*' ) === strlen( $redirect_to ) - 1 ) ) {
 						$redirect_to = rtrim( $redirect_to, '*' ) . ltrim( substr( $requested_path, strlen( $wildcard_base ) ), '/' );
 					}

--- a/tests/php/test-core.php
+++ b/tests/php/test-core.php
@@ -576,8 +576,8 @@ class SRMTestCore extends WP_UnitTestCase {
 		srm_create_redirect( '/one/*', $redirect_to );
 		add_action(
 			'srm_do_redirect',
-			function( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected, &$expected ) {
-					$redirected = true;
+			function() use ( &$redirected ) {
+				$redirected = true;
 			},
 			10,
 			3

--- a/tests/php/test-core.php
+++ b/tests/php/test-core.php
@@ -567,7 +567,7 @@ class SRMTestCore extends WP_UnitTestCase {
 	/**
 	 * Test a redirect rule with a wildcard that shouldn't match.
 	 */
-	public function testNoRedirectWildcardGeneralized() {
+	public function testNoRedirectWildcard() {
 		$_SERVER['REQUEST_URI'] = '/one-page/';
 		$redirected             = false;
 		$redirect_to            = '/gohere';

--- a/tests/php/test-core.php
+++ b/tests/php/test-core.php
@@ -565,6 +565,29 @@ class SRMTestCore extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test a redirect rule with a wildcard that shouldn't match.
+	 */
+	public function testNoRedirectWildcardGeneralized() {
+		$_SERVER['REQUEST_URI'] = '/one-page/';
+		$redirected             = false;
+		$redirect_to            = '/gohere';
+
+		// Create redirect for testing.
+		srm_create_redirect( '/one/*', $redirect_to );
+		add_action(
+			'srm_do_redirect',
+			function( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected, &$expected ) {
+					$redirected = true;
+			},
+			10,
+			3
+		);
+
+		SRM_Redirect::factory()->maybe_redirect();
+		$this->assertFalse( $redirected, 'Expected that /one-page/ would not redirect, but instead redirected to ' . $redirect_to );
+	}
+
+	/**
 	 * Test a URL that shouldn't redirect.
 	 */
 	public function testNoRedirect() {


### PR DESCRIPTION
### Description of the Change

Fixes #208.

This PR fixes a regression introduced in 1.9.3 that caused paths to match erroneously against a rule ending in `/*`.

### Alternate Designs

None.

### Benefits

* Improved handling for wildcard redirects.

### Possible Drawbacks

* Nothing immediately obvious, but there's perhaps the potential to break redirects in unforeseen scenarios not currently accounted for in test cases.

### Verification Process

* Added a test to address the case.
* Existing tests still pass.
* Tested within a project.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my change.
- [X] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

#208

### Changelog Entry

* Fixed: Regression related to wildcard matching
