### PR TITLE
Added header for the redirect from Post ID 

### DIFF
--- a/inc/classes/class-srm-redirect.php
+++ b/inc/classes/class-srm-redirect.php
@@ -209,7 +209,7 @@ class SRM_Redirect {
 		}
 
 		header( 'X-Safe-Redirect-Manager: true' );
-		header( 'X-Safe-Redirect-Post-ID: ' . esc_attr( $matched_redirect['redirect_post_id'] ) );
+		header( 'X-Safe-Redirect-ID: ' . esc_attr( $matched_redirect['redirect_post_id'] ) );
 
 		// if we have a valid status code, then redirect with it
 		if ( in_array( $matched_redirect['status_code'], srm_get_valid_status_codes(), true ) ) {

--- a/inc/classes/class-srm-redirect.php
+++ b/inc/classes/class-srm-redirect.php
@@ -105,10 +105,10 @@ class SRM_Redirect {
 				$redirect_from = '/'; // this only happens in the case where there is a redirect on the root
 			}
 
-			$redirect_to      = $redirect['redirect_to'];
-			$status_code      = $redirect['status_code'];
-			$enable_regex     = ( isset( $redirect['enable_regex'] ) ) ? $redirect['enable_regex'] : false;
-			$redirect_post_id = $redirect['ID'];
+			$redirect_to  = $redirect['redirect_to'];
+			$status_code  = $redirect['status_code'];
+			$enable_regex = ( isset( $redirect['enable_regex'] ) ) ? $redirect['enable_regex'] : false;
+			$redirect_id  = $redirect['ID'];
 
 			// check if the redirection destination is valid, otherwise just skip it
 			if ( empty( $redirect_to ) ) {
@@ -163,10 +163,10 @@ class SRM_Redirect {
 				$sanitized_redirect_to = esc_url_raw( apply_filters( 'srm_redirect_to', $redirect_to ) );
 
 				return [
-					'redirect_to'      => $sanitized_redirect_to,
-					'status_code'      => $status_code,
-					'enable_regex'     => $enable_regex,
-					'redirect_post_id' => $redirect_post_id,
+					'redirect_to'  => $sanitized_redirect_to,
+					'status_code'  => $status_code,
+					'enable_regex' => $enable_regex,
+					'redirect_id'  => $redirect_id,
 				];
 			}
 		}
@@ -209,7 +209,7 @@ class SRM_Redirect {
 		}
 
 		header( 'X-Safe-Redirect-Manager: true' );
-		header( 'X-Safe-Redirect-ID: ' . esc_attr( $matched_redirect['redirect_post_id'] ) );
+		header( 'X-Safe-Redirect-ID: ' . esc_attr( $matched_redirect['redirect_id'] ) );
 
 		// if we have a valid status code, then redirect with it
 		if ( in_array( $matched_redirect['status_code'], srm_get_valid_status_codes(), true ) ) {

--- a/inc/classes/class-srm-redirect.php
+++ b/inc/classes/class-srm-redirect.php
@@ -105,9 +105,10 @@ class SRM_Redirect {
 				$redirect_from = '/'; // this only happens in the case where there is a redirect on the root
 			}
 
-			$redirect_to  = $redirect['redirect_to'];
-			$status_code  = $redirect['status_code'];
-			$enable_regex = ( isset( $redirect['enable_regex'] ) ) ? $redirect['enable_regex'] : false;
+			$redirect_to      = $redirect['redirect_to'];
+			$status_code      = $redirect['status_code'];
+			$enable_regex     = ( isset( $redirect['enable_regex'] ) ) ? $redirect['enable_regex'] : false;
+			$redirect_post_id = $redirect['ID'];
 
 			// check if the redirection destination is valid, otherwise just skip it
 			if ( empty( $redirect_to ) ) {
@@ -162,9 +163,10 @@ class SRM_Redirect {
 				$sanitized_redirect_to = esc_url_raw( apply_filters( 'srm_redirect_to', $redirect_to ) );
 
 				return [
-					'redirect_to'  => $sanitized_redirect_to,
-					'status_code'  => $status_code,
-					'enable_regex' => $enable_regex,
+					'redirect_to'      => $sanitized_redirect_to,
+					'status_code'      => $status_code,
+					'enable_regex'     => $enable_regex,
+					'redirect_post_id' => $redirect_post_id,
 				];
 			}
 		}
@@ -207,6 +209,7 @@ class SRM_Redirect {
 		}
 
 		header( 'X-Safe-Redirect-Manager: true' );
+		header( 'X-Safe-Redirect-Post-ID: ' . esc_attr( $matched_redirect['redirect_post_id'] ) );
 
 		// if we have a valid status code, then redirect with it
 		if ( in_array( $matched_redirect['status_code'], srm_get_valid_status_codes(), true ) ) {


### PR DESCRIPTION

### Description of the Change

This PR adds the redirect post ID to the HTTP response headers. Its' purpose is to aid debugging where a redirect is coming from.

Where there are a large number of similar redirects e.g. for "reviews" it can be hard to pinpoint exactly where the active redirect is coming from.

### Alternate Designs

N/A

### Benefits

The addition of the Post ID will help developers see which redirect rule took effect.

### Possible Drawbacks

The ID of the redirect post will be available to anyone looking at the headers. I don't believe this is a security concern since external users won't be able to achieve anything with this.

### Verification Process

I set up a local install with SRM as the only active plugin; I setup a redirect, cleared the transient cache and loaded the URL that would trigger the redirect rule.

I confirmed that the post ID (`5` in this case) shows in the response headers.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

N / A - this doesn't directly relate to an issue here, I just needed to debug where a redirect was coming from.

### Changelog Entry

Added redirect Post ID to response headers where a redirect rule is invoked.