### PR TITLE
Fix missing 'order' column in CSV import command

### DIFF
--- a/inc/classes/class-srm-wp-cli.php
+++ b/inc/classes/class-srm-wp-cli.php
@@ -244,6 +244,7 @@ class SRM_WP_CLI extends WP_CLI_Command {
 				'target' => 'target',
 				'regex'  => 'regex',
 				'code'   => 'code',
+				'order'  => 'order',
 			)
 		);
 


### PR DESCRIPTION
The CSV import command expects an 'order' column but does not set one in its default mapping, causing a PHP warning when the CLI importing command calls the srm_import_file() function.

This update adds the 'order' column to the default columns array.
