### PR TITLE
Add: srm_redirect_only_on_404 documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,20 @@ so you shouldn't be serving stale redirects.
 `srm_max_redirects` that you can utilize to up this number.
 * "Redirect From" and requested paths are case insensitive by default.
 
-## Redirect loops
+## Filters
+### Redirect loops detection
 
 By default redirect loop detection is disabled. To prevent redirect loops you can filter `srm_check_for_possible_redirect_loops`.
 
 ```php
 add_filter( 'srm_check_for_possible_redirect_loops', '__return_true' );
+```
+
+### Only redirect if 404 occurs
+
+By default, SRM redirects every matched URL. To only redirect matched but not found URL (404 pages), use `srm_redirect_only_on_404`.
+```php
+add_filter( 'srm_redirect_only_on_404', '__return_true' );
 ```
 
 ## CLI commands

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ so you shouldn't be serving stale redirects.
 * "Redirect From" and requested paths are case insensitive by default.
 
 ## Filters
+
 ### Redirect loops detection
 
 By default redirect loop detection is disabled. To prevent redirect loops you can filter `srm_check_for_possible_redirect_loops`.
@@ -65,7 +66,8 @@ add_filter( 'srm_check_for_possible_redirect_loops', '__return_true' );
 
 ### Only redirect if 404 occurs
 
-By default, SRM redirects every matched URL. To only redirect matched but not found URL (404 pages), use `srm_redirect_only_on_404`.
+By default every matched URL is redirected. To only redirect matched but not found URLs (i.e., 404 pages), use `srm_redirect_only_on_404`.
+
 ```php
 add_filter( 'srm_redirect_only_on_404', '__return_true' );
 ```


### PR DESCRIPTION
This PR add documentation for `srm_redirect_only_on_404` filter. It also updates the readme file to add a dedicated *Filters* section.

Fixes #221 