### PR TITLE
Fix required parameter message in PHP 8.0

### DIFF
--- a/inc/classes/class-srm-post-type.php
+++ b/inc/classes/class-srm-post-type.php
@@ -91,11 +91,11 @@ class SRM_Post_Type {
 	 * Remove quick edit
 	 *
 	 * @param  array   $actions Array of actions
-	 * @param  WP_Post $post Post object
+	 * @param  int|WP_Post|null $post Post object
 	 * @since  1.8
 	 * @return array
 	 */
-	public function filter_disable_quick_edit( $actions = array(), $post ) {
+	public function filter_disable_quick_edit( $actions = array(), $post = null ) {
 		if ( 'redirect_rule' === get_post_type( $post ) && isset( $actions['inline hide-if-no-js'] ) ) {
 			unset( $actions['inline hide-if-no-js'] );
 			unset( $actions['view'] );

--- a/inc/classes/class-srm-post-type.php
+++ b/inc/classes/class-srm-post-type.php
@@ -90,7 +90,7 @@ class SRM_Post_Type {
 	/**
 	 * Remove quick edit
 	 *
-	 * @param  array   $actions Array of actions
+	 * @param  array            $actions Array of actions
 	 * @param  int|WP_Post|null $post Post object
 	 * @since  1.8
 	 * @return array

--- a/inc/classes/class-srm-post-type.php
+++ b/inc/classes/class-srm-post-type.php
@@ -95,7 +95,7 @@ class SRM_Post_Type {
 	 * @since  1.8
 	 * @return array
 	 */
-	public function filter_disable_quick_edit( $actions = array(), $post = null ) {
+	public function filter_disable_quick_edit( $actions, $post ) {
 		if ( 'redirect_rule' === get_post_type( $post ) && isset( $actions['inline hide-if-no-js'] ) ) {
 			unset( $actions['inline hide-if-no-js'] );
 			unset( $actions['view'] );


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This fixes the following message:

```
Deprecated: Required parameter $post follows optional parameter $actions in safe-redirect-manager/inc/classes/class-srm-post-type.php on line 98
```

`$post` can be either `int|WP_Post|null`: https://developer.wordpress.org/reference/functions/get_post_type/
<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

N/A

### Benefits

<!-- What benefits will be realized by the code change? -->

The message will now longer be visible.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

N/A

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

I tried to update the plugin in a local WordPress application running PHP 8.0.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

Fix required parameter following optional deprecated message in PHP 8

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
