### PR TITLE
Update/tested up to 5.6 on `develop`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,7 +7,6 @@
 /.editorconfig export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
-/.travis.yml export-ignore
 /CHANGELOG.md export-ignore
 /CODE_OF_CONDUCT.md export-ignore
 /composer.json export-ignore

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > A WordPress plugin to safely and easily manage your website's HTTP redirects.
 
-[![Support Level](https://img.shields.io/badge/support-active-green.svg)](#support-level) [![Build Status](https://travis-ci.org/10up/safe-redirect-manager.svg?branch=develop)](https://travis-ci.org/10up/safe-redirect-manager) [![Release Version](https://img.shields.io/github/release/10up/safe-redirect-manager.svg)](https://github.com/10up/safe-redirect-manager/releases/latest) ![WordPress tested up to version](https://img.shields.io/badge/WordPress-v5.5.3%20tested-success.svg) [![GPLv2 License](https://img.shields.io/github/license/10up/safe-redirect-manager.svg)](https://github.com/10up/safe-redirect-manager/blob/develop/LICENSE.md)
+[![Support Level](https://img.shields.io/badge/support-active-green.svg)](#support-level) [![Build Status](https://travis-ci.org/10up/safe-redirect-manager.svg?branch=develop)](https://travis-ci.org/10up/safe-redirect-manager) [![Release Version](https://img.shields.io/github/release/10up/safe-redirect-manager.svg)](https://github.com/10up/safe-redirect-manager/releases/latest) ![WordPress tested up to version](https://img.shields.io/badge/WordPress-v5.6%20tested-success.svg) [![GPLv2 License](https://img.shields.io/github/license/10up/safe-redirect-manager.svg)](https://github.com/10up/safe-redirect-manager/blob/develop/LICENSE.md)
 
 ## Purpose
 

--- a/package.json
+++ b/package.json
@@ -1,12 +1,23 @@
 {
   "name": "safe-redirect-manager",
+  "version": "1.10.0",
   "description": "Easily and safely manage HTTP redirects.",
-  "dependencies": {
-    "node-wp-i18n": "^1.0.4"
+  "homepage": "https://github.com/10up/safe-redirect-manager",
+  "bugs": {
+    "url" : "https://github.com/10up/safe-redirect-manager/issues"
   },
-  "author": "10up",
+  "license": "GPL-2.0-or-later",
+  "author": {
+    "name": "10up",
+    "email": "opensource@10up.com",
+    "url": "https://10up.com",
+    "role": "developer"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/10up/safe-redirect-manager"
+  },
+  "dependencies": {
+    "node-wp-i18n": "^1.2.5"
   },
 }

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: tlovett1, tollmanz, taylorde, 10up, jakemgold, danielbachhuber, VentureBeat
 Tags: http redirects, redirect manager, url redirection, safe http redirection, multisite redirects, redirects
 Requires at least: 4.6
-Tested up to: 5.5.3
+Tested up to: 5.6
 Stable tag: 1.10.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This PR bumps the WordPress tested-up-to value to 5.6, tidies up the .gitattributes and package.json files, and bumps a dependency in the package.json file.  Most of these changes are pulled from the aborted #230 release as it was no longer needed, but had these minimal through worthwhile updates for the plugin.

### Alternate Designs

n/a

### Benefits

Ensures we represent the latest WordPress version the plugin has been tested for.

### Possible Drawbacks

none identified

### Verification Process

Manually verified in VS Code and the GitHub Desktop UI.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

Closes #227.

### Changelog Entry

n/a
