### PR TITLE
Fix: $parsed_requested_path['path'] doesn't always exits

### DIFF
--- a/inc/classes/class-srm-redirect.php
+++ b/inc/classes/class-srm-redirect.php
@@ -113,7 +113,13 @@ class SRM_Redirect {
 			$parsed_requested_path = parse_url( $normalized_requested_path );
 		}
 		// Normalize the request path with and without query strings, for comparison later
-		$requested_query_params = '';
+		$normalized_requested_path_no_query = '';
+		$requested_query_params             = '';
+
+		if ( ! empty( $parsed_requested_path['path'] ) ) {
+			$normalized_requested_path_no_query = untrailingslashit( stripslashes( $parsed_requested_path['path'] ) );
+		}
+
 		if ( ! empty( $parsed_requested_path['query'] ) ) {
 			$requested_query_params = $parsed_requested_path['query'];
 		}

--- a/inc/classes/class-srm-redirect.php
+++ b/inc/classes/class-srm-redirect.php
@@ -124,8 +124,6 @@ class SRM_Redirect {
 			$requested_query_params = $parsed_requested_path['query'];
 		}
 
-		$normalized_requested_path_no_query = untrailingslashit( stripslashes( $parsed_requested_path['path'] ) );
-
 		foreach ( (array) $redirects as $redirect ) {
 
 			$redirect_from = untrailingslashit( $redirect['redirect_from'] );


### PR DESCRIPTION
### Description of the Change
In #196 we add a feature to redirect URL with params. We parse URL in that feature and assume that the parsed path always exists, but `parse_url` can return `false` in some edge cases. So this PR adds a check to cover those cases.

Fixes #244.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->