### PR TITLE
Added some additional E2E tests

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -29,3 +29,13 @@ jobs:
       run: npm run env:start
     - name: Test
       run: npm run cypress:run
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: cypress-artifact-safe-redirect-manager
+        retention-days: 7
+        path: |
+          ${{ github.workspace }}/tests/cypress/screenshots/
+          ${{ github.workspace }}/tests/cypress/videos/
+          ${{ github.workspace }}/tests/cypress/logs/

--- a/tests/cypress/integration/safe-redirect-manager.test.js
+++ b/tests/cypress/integration/safe-redirect-manager.test.js
@@ -65,7 +65,7 @@ describe('Test redirect rules', () => {
 		cy.url().should('include', '/hello-world');
 	});
 
-	it.skip('Can redirect a wildcard rule request', () => {
+	it('Can redirect a wildcard rule request', () => {
 		// no leading slash, no trailing slash
 		cy.createRedirectRule('test*', 'sample-page', 'Wildcard rule note (no leading slash, no trailing slash)');
 		cy.visit('/test-1');

--- a/tests/cypress/integration/safe-redirect-manager.test.js
+++ b/tests/cypress/integration/safe-redirect-manager.test.js
@@ -96,17 +96,18 @@ describe('Test redirect rules', () => {
 	});
 
 	it('Can redirect a Regex rule request', () => {
-		// no leading slash, no trailing slash
-		cy.createRedirectRule(
-			'blog/(.*)',
-			'hello-world',
-			'Regex rule note (no leading slash, no trailing slash)',
-			true
-		);
-		cy.visit('/blog/1');
-		cy.url().should('include', '/hello-world');
-		cy.visit('/blog/1/');
-		cy.url().should('include', '/hello-world');
+		// TODO: Uncomment this test case once issue #269 get resolved.
+		// // no leading slash, no trailing slash
+		// cy.createRedirectRule(
+		// 	'blog/(.*)',
+		// 	'hello-world',
+		// 	'Regex rule note (no leading slash, no trailing slash)',
+		// 	true
+		// );
+		// cy.visit('/blog/1');
+		// cy.url().should('include', '/hello-world');
+		// cy.visit('/blog/1/');
+		// cy.url().should('include', '/hello-world');
 
 		// leading slash, no trailing slash
 		cy.createRedirectRule(
@@ -120,17 +121,18 @@ describe('Test redirect rules', () => {
 		cy.visit('/blog-2/1/');
 		cy.url().should('include', '/hello-world');
 
-		// no leading slash, trailing slash
-		cy.createRedirectRule(
-			'blog-3/(.*)/',
-			'hello-world/',
-			'Regex rule note (no leading slash, trailing slash)',
-			true
-		);
-		cy.visit('/blog-3/1');
-		cy.url().should('include', '/hello-world');
-		cy.visit('/blog-3/1/');
-		cy.url().should('include', '/hello-world');
+		// TODO: Uncomment this test case once issue #269 get resolved.
+		// // no leading slash, trailing slash
+		// cy.createRedirectRule(
+		// 	'blog-3/(.*)/',
+		// 	'hello-world/',
+		// 	'Regex rule note (no leading slash, trailing slash)',
+		// 	true
+		// );
+		// cy.visit('/blog-3/1');
+		// cy.url().should('include', '/hello-world');
+		// cy.visit('/blog-3/1/');
+		// cy.url().should('include', '/hello-world');
 
 		// leading slash, trailing slash
 		cy.createRedirectRule(

--- a/tests/cypress/integration/safe-redirect-manager.test.js
+++ b/tests/cypress/integration/safe-redirect-manager.test.js
@@ -96,14 +96,52 @@ describe('Test redirect rules', () => {
 	});
 
 	it('Can redirect a Regex rule request', () => {
+		// no leading slash, no trailing slash
 		cy.createRedirectRule(
-			'/blog/(.*)',
-			'/hello-world',
-			'Regex rule note',
+			'blog/(.*)',
+			'hello-world',
+			'Regex rule note (no leading slash, no trailing slash)',
 			true
 		);
-
 		cy.visit('/blog/1');
+		cy.url().should('include', '/hello-world');
+		cy.visit('/blog/1/');
+		cy.url().should('include', '/hello-world');
+
+		// leading slash, no trailing slash
+		cy.createRedirectRule(
+			'/blog-2/(.*)',
+			'/hello-world',
+			'Regex rule note (leading slash, no trailing slash)',
+			true
+		);
+		cy.visit('/blog-2/1');
+		cy.url().should('include', '/hello-world');
+		cy.visit('/blog-2/1/');
+		cy.url().should('include', '/hello-world');
+
+		// no leading slash, trailing slash
+		cy.createRedirectRule(
+			'blog-3/(.*)/',
+			'hello-world/',
+			'Regex rule note (no leading slash, trailing slash)',
+			true
+		);
+		cy.visit('/blog-3/1');
+		cy.url().should('include', '/hello-world');
+		cy.visit('/blog-3/1/');
+		cy.url().should('include', '/hello-world');
+
+		// leading slash, trailing slash
+		cy.createRedirectRule(
+			'/blog-4/(.*)/',
+			'/hello-world/',
+			'Regex rule note (leading slash, trailing slash)',
+			true
+		);
+		cy.visit('/blog-4/1');
+		cy.url().should('include', '/hello-world');
+		cy.visit('/blog-4/1/');
 		cy.url().should('include', '/hello-world');
 	});
 });

--- a/tests/cypress/integration/safe-redirect-manager.test.js
+++ b/tests/cypress/integration/safe-redirect-manager.test.js
@@ -65,10 +65,33 @@ describe('Test redirect rules', () => {
 		cy.url().should('include', '/hello-world');
 	});
 
-	it('Can redirect a wildcard rule request', () => {
-		cy.createRedirectRule('/test*', '/sample-page', 'Wildcard rule note');
-
+	it.skip('Can redirect a wildcard rule request', () => {
+		// no leading slash, no trailing slash
+		cy.createRedirectRule('test*', 'sample-page', 'Wildcard rule note (no leading slash, no trailing slash)');
 		cy.visit('/test-1');
+		cy.url().should('include', '/sample-page');
+		cy.visit('/test-1/');
+		cy.url().should('include', '/sample-page');
+
+		// leading slash, no trailing slash
+		cy.createRedirectRule('/2-test*', '/sample-page', 'Wildcard rule note (leading slash, no trailing slash)');
+		cy.visit('/2-test-1');
+		cy.url().should('include', '/sample-page');
+		cy.visit('/2-test-1/');
+		cy.url().should('include', '/sample-page');
+
+		// no leading slash, trailing slash
+		cy.createRedirectRule('3-test*/', 'sample-page/', 'Wildcard rule note (no leading slash, trailing slash)');
+		cy.visit('/3-test-1');
+		cy.url().should('include', '/sample-page');
+		cy.visit('/3-test-1/');
+		cy.url().should('include', '/sample-page');
+
+		// leading slash, trailing slash
+		cy.createRedirectRule('/4-test*/', '/sample-page/', 'Wildcard rule note (leading slash, trailing slash)');
+		cy.visit('/4-test-1');
+		cy.url().should('include', '/sample-page');
+		cy.visit('/4-test-1/');
 		cy.url().should('include', '/sample-page');
 	});
 

--- a/tests/cypress/integration/safe-redirect-manager.test.js
+++ b/tests/cypress/integration/safe-redirect-manager.test.js
@@ -19,13 +19,49 @@ describe('Test redirect rules', () => {
 	});
 
 	it('Can redirect a simple rule request', () => {
+		// no leading slash, no trailing slash
 		cy.createRedirectRule(
-			'/first-blog',
-			'/hello-world',
-			'Simple rule note'
+			'first-blog',
+			'hello-world',
+			'Simple rule note (no leading slash, no trailing slash)'
 		);
-
 		cy.visit('/first-blog');
+		cy.url().should('include', '/hello-world');
+		cy.visit('/first-blog/');
+		cy.url().should('include', '/hello-world');
+
+
+		// leading slash, no trailing slash
+		cy.createRedirectRule(
+			'/first-blog-2',
+			'/hello-world',
+			'Simple rule note (leading slash, no trailing slash)'
+		);
+		cy.visit('/first-blog-2');
+		cy.url().should('include', '/hello-world');
+		cy.visit('/first-blog-2/');
+		cy.url().should('include', '/hello-world');
+
+		// no leading slash, trailing slash
+		cy.createRedirectRule(
+			'first-blog-3/',
+			'hello-world/',
+			'Simple rule note (no leading slash, trailing slash)'
+		);
+		cy.visit('/first-blog-3');
+		cy.url().should('include', '/hello-world');
+		cy.visit('/first-blog-3/');
+		cy.url().should('include', '/hello-world');
+
+		// leading slash, trailing slash
+		cy.createRedirectRule(
+			'/first-blog-4/',
+			'/hello-world/',
+			'Simple rule note (leading slash, trailing slash)'
+		);
+		cy.visit('/first-blog-4');
+		cy.url().should('include', '/hello-world');
+		cy.visit('/first-blog-4/');
 		cy.url().should('include', '/hello-world');
 	});
 

--- a/tests/cypress/integration/safe-redirect-manager.test.js
+++ b/tests/cypress/integration/safe-redirect-manager.test.js
@@ -25,11 +25,7 @@ describe('Test redirect rules', () => {
 			'hello-world',
 			'Simple rule note (no leading slash, no trailing slash)'
 		);
-		cy.visit('/first-blog');
-		cy.url().should('include', '/hello-world');
-		cy.visit('/first-blog/');
-		cy.url().should('include', '/hello-world');
-
+		cy.verifyRedirectRule('first-blog', '/hello-world');
 
 		// leading slash, no trailing slash
 		cy.createRedirectRule(
@@ -37,10 +33,7 @@ describe('Test redirect rules', () => {
 			'/hello-world',
 			'Simple rule note (leading slash, no trailing slash)'
 		);
-		cy.visit('/first-blog-2');
-		cy.url().should('include', '/hello-world');
-		cy.visit('/first-blog-2/');
-		cy.url().should('include', '/hello-world');
+		cy.verifyRedirectRule('first-blog-2', '/hello-world');
 
 		// no leading slash, trailing slash
 		cy.createRedirectRule(
@@ -48,10 +41,7 @@ describe('Test redirect rules', () => {
 			'hello-world/',
 			'Simple rule note (no leading slash, trailing slash)'
 		);
-		cy.visit('/first-blog-3');
-		cy.url().should('include', '/hello-world');
-		cy.visit('/first-blog-3/');
-		cy.url().should('include', '/hello-world');
+		cy.verifyRedirectRule('first-blog-3', '/hello-world');
 
 		// leading slash, trailing slash
 		cy.createRedirectRule(
@@ -59,40 +49,25 @@ describe('Test redirect rules', () => {
 			'/hello-world/',
 			'Simple rule note (leading slash, trailing slash)'
 		);
-		cy.visit('/first-blog-4');
-		cy.url().should('include', '/hello-world');
-		cy.visit('/first-blog-4/');
-		cy.url().should('include', '/hello-world');
+		cy.verifyRedirectRule('first-blog-4', '/hello-world');
 	});
 
 	it('Can redirect a wildcard rule request', () => {
 		// no leading slash, no trailing slash
 		cy.createRedirectRule('test*', 'sample-page', 'Wildcard rule note (no leading slash, no trailing slash)');
-		cy.visit('/test-1');
-		cy.url().should('include', '/sample-page');
-		cy.visit('/test-1/');
-		cy.url().should('include', '/sample-page');
+		cy.verifyRedirectRule('test-1', '/sample-page');
 
 		// leading slash, no trailing slash
 		cy.createRedirectRule('/2-test*', '/sample-page', 'Wildcard rule note (leading slash, no trailing slash)');
-		cy.visit('/2-test-1');
-		cy.url().should('include', '/sample-page');
-		cy.visit('/2-test-1/');
-		cy.url().should('include', '/sample-page');
+		cy.verifyRedirectRule('2-test-1', '/sample-page');
 
 		// no leading slash, trailing slash
 		cy.createRedirectRule('3-test*/', 'sample-page/', 'Wildcard rule note (no leading slash, trailing slash)');
-		cy.visit('/3-test-1');
-		cy.url().should('include', '/sample-page');
-		cy.visit('/3-test-1/');
-		cy.url().should('include', '/sample-page');
+		cy.verifyRedirectRule('3-test-1', '/sample-page');
 
 		// leading slash, trailing slash
 		cy.createRedirectRule('/4-test*/', '/sample-page/', 'Wildcard rule note (leading slash, trailing slash)');
-		cy.visit('/4-test-1');
-		cy.url().should('include', '/sample-page');
-		cy.visit('/4-test-1/');
-		cy.url().should('include', '/sample-page');
+		cy.verifyRedirectRule('4-test-1', '/sample-page');
 	});
 
 	it('Can redirect a Regex rule request', () => {
@@ -104,10 +79,7 @@ describe('Test redirect rules', () => {
 		// 	'Regex rule note (no leading slash, no trailing slash)',
 		// 	true
 		// );
-		// cy.visit('/blog/1');
-		// cy.url().should('include', '/hello-world');
-		// cy.visit('/blog/1/');
-		// cy.url().should('include', '/hello-world');
+		// cy.verifyRedirectRule('blog/1', '/hello-world');
 
 		// leading slash, no trailing slash
 		cy.createRedirectRule(
@@ -116,10 +88,7 @@ describe('Test redirect rules', () => {
 			'Regex rule note (leading slash, no trailing slash)',
 			true
 		);
-		cy.visit('/blog-2/1');
-		cy.url().should('include', '/hello-world');
-		cy.visit('/blog-2/1/');
-		cy.url().should('include', '/hello-world');
+		cy.verifyRedirectRule('blog-2/1', '/hello-world');
 
 		// TODO: Uncomment this test case once issue #269 get resolved.
 		// // no leading slash, trailing slash
@@ -129,10 +98,7 @@ describe('Test redirect rules', () => {
 		// 	'Regex rule note (no leading slash, trailing slash)',
 		// 	true
 		// );
-		// cy.visit('/blog-3/1');
-		// cy.url().should('include', '/hello-world');
-		// cy.visit('/blog-3/1/');
-		// cy.url().should('include', '/hello-world');
+		// cy.verifyRedirectRule('blog-3/1', '/hello-world');
 
 		// leading slash, trailing slash
 		cy.createRedirectRule(
@@ -141,9 +107,6 @@ describe('Test redirect rules', () => {
 			'Regex rule note (leading slash, trailing slash)',
 			true
 		);
-		cy.visit('/blog-4/1');
-		cy.url().should('include', '/hello-world');
-		cy.visit('/blog-4/1/');
-		cy.url().should('include', '/hello-world');
+		cy.verifyRedirectRule('blog-4/1', '/hello-world');
 	});
 });

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -37,3 +37,10 @@ Cypress.Commands.add('createRedirectRule', (from, to, notes = '', regex = false 
 	cy.get('#publish').click();
 	cy.get( '.updated' ).should( 'be.visible' );
 });
+
+Cypress.Commands.add('verifyRedirectRule', (from, to) => {
+	cy.visit(`/${from}`);
+	cy.url().should('include', to);
+	cy.visit(`/${from}/`);
+	cy.url().should('include', to);
+});


### PR DESCRIPTION
### Description of the Change
This PR adds some additional test cases for e2e tests, Added redirect rules with multiple slash setups like mentioned below.
- no leading slash, no trailing slash
- leading slash, no trailing slash
- no leading slash, trailing slash
- leading slash, trailing slash

_**Note: 2 Test cases are failing because of the bug https://github.com/10up/safe-redirect-manager/issues/269, those tests are commented for now until bug get fixed.**_ 

<!-- Enter any applicable Issues here. Example: -->
Closes #271

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
E2E tests in GH action should `PASS`.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry
> Added - Some additional E2E test cases

### Credits
Props @iamdharmesh 
