### PR TITLE
Add support for notes when importing redirects

### DIFF
--- a/inc/classes/class-srm-wp-cli.php
+++ b/inc/classes/class-srm-wp-cli.php
@@ -224,12 +224,12 @@ class SRM_WP_CLI extends WP_CLI_Command {
 	 * redirection from and to URLs, regex flag and HTTP redirection code. Here
 	 * is example table:
 	 *
-	 * | source                     | target             | regex | code | order |
-	 * |----------------------------|--------------------|-------|------|-------|
-	 * | /legacy-url                | /new-url           | 0     | 301  | 0     |
-	 * | /category-1                | /new-category-slug | 0     | 302  | 1     |
-	 * | /tes?t/[0-9]+/path/[^/]+/? | /go/here           | 1     | 302  | 3     |
-	 * | ...                        | ...                | ...   | ...  | ...   |
+	 * | source                     | target             | regex | code | order | notes |
+	 * |----------------------------|--------------------|-------|------|-------|-------|
+	 * | /legacy-url                | /new-url           | 0     | 301  | 0     |       |
+	 * | /category-1                | /new-category-slug | 0     | 302  | 1     |       |
+	 * | /tes?t/[0-9]+/path/[^/]+/? | /go/here           | 1     | 302  | 3     |       |
+	 * | ...                        | ...                | ...   | ...  | ...   | ...   |
 	 *
 	 * You can also use exported redirects from "Redirection" plugin, which you
 	 * can download here: /wp-admin/tools.php?page=redirection.php&sub=modules
@@ -249,12 +249,14 @@ class SRM_WP_CLI extends WP_CLI_Command {
 	 * <order-column>
 	 * : Header title for order column mapping.
 	 *
+	 * <notes-column>
+	 * : Header title for notes column mapping.
 	 *
 	 * ## EXAMPLE
 	 *
 	 *     wp safe-redirect-manager import redirections.csv
 	 *
-	 * @synopsis <file> [--source=<source-column>] [--target=<target-column>] [--regex=<regex-column>] [--code=<code-column>]  [--order=<order-column>]
+	 * @synopsis <file> [--source=<source-column>] [--target=<target-column>] [--regex=<regex-column>] [--code=<code-column>]  [--order=<order-column>] [--notes=<notes-column>]
 	 *
 	 * @since 1.7.6
 	 *
@@ -271,6 +273,7 @@ class SRM_WP_CLI extends WP_CLI_Command {
 				'regex'  => 'regex',
 				'code'   => 'code',
 				'order'  => 'order',
+				'notes'  => 'notes',
 			)
 		);
 

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -369,9 +369,10 @@ function srm_import_file( $file, $args ) {
 		$status_code   = ! empty( $rule[ $args['code'] ] ) ? $rule[ $args['code'] ] : 302;
 		$regex         = ! empty( $rule[ $args['regex'] ] ) ? filter_var( $rule[ $args['regex'] ], FILTER_VALIDATE_BOOLEAN ) : false;
 		$menu_order    = ! empty( $rule[ $args['order'] ] ) ? $rule[ $args['order'] ] : 0;
+		$notes         = ! empty( $rule[ $args['notes'] ] ) ? $rule[ $args['notes'] ] : '';
 
 		// import
-		$id = srm_create_redirect( $redirect_from, $redirect_to, $status_code, $regex, 'publish', $menu_order );
+		$id = srm_create_redirect( $redirect_from, $redirect_to, $status_code, $regex, 'publish', $menu_order, $notes );
 
 		if ( is_wp_error( $id ) ) {
 			$doing_wp_cli && WP_CLI::warning( $id );

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -198,11 +198,12 @@ function srm_check_for_possible_redirect_loops() {
  * @param bool   $enable_regex Whether to enable regex or not
  * @param string $post_status Post status
  * @param int    $menu_order Menu order
+ * @param string $notes Notes
  * @since 1.8
  * @uses wp_insert_post, update_post_meta
  * @return int|WP_Error
  */
-function srm_create_redirect( $redirect_from, $redirect_to, $status_code = 302, $enable_regex = false, $post_status = 'publish', $menu_order = 0 ) {
+function srm_create_redirect( $redirect_from, $redirect_to, $status_code = 302, $enable_regex = false, $post_status = 'publish', $menu_order = 0, $notes = '' ) {
 	global $wpdb;
 
 	$sanitized_redirect_from = srm_sanitize_redirect_from( $redirect_from );
@@ -211,6 +212,7 @@ function srm_create_redirect( $redirect_from, $redirect_to, $status_code = 302, 
 	$sanitized_enable_regex  = (bool) $enable_regex;
 	$sanitized_post_status   = sanitize_key( $post_status );
 	$sanitized_menu_order    = absint( $menu_order );
+	$sanitized_notes         = sanitize_text_field( $notes );
 
 	// check and make sure no parameters are empty or invalid after sanitation
 	if ( empty( $sanitized_redirect_from ) || empty( $sanitized_redirect_to ) ) {
@@ -245,6 +247,7 @@ function srm_create_redirect( $redirect_from, $redirect_to, $status_code = 302, 
 	update_post_meta( $post_id, '_redirect_rule_to', $sanitized_redirect_to );
 	update_post_meta( $post_id, '_redirect_rule_status_code', $sanitized_status_code );
 	update_post_meta( $post_id, '_redirect_rule_from_regex', $sanitized_enable_regex );
+	update_post_meta( $post_id, '_redirect_rule_notes', $sanitized_notes );
 
 	// We need to update the cache after creating this redirect
 	srm_flush_cache();

--- a/tests/php/test-core.php
+++ b/tests/php/test-core.php
@@ -479,11 +479,11 @@ class SRMTestCore extends WP_UnitTestCase {
 
 		$redirects = array(
 			// headers
-			array( 'http code', 'legacy url', 'new url', 'is_regex', 'order' ),
+			array( 'http code', 'legacy url', 'new url', 'is_regex', 'order', 'notes' ),
 			// redirects
-			array( 302, '/some-url', '/new-url', 0, 0 ),
-			array( 301, '/broken-url', '/fixed-url', 0, 0 ),
-			array( 301, '/reg?ex/\d+/path', '/go/here', 1, 0 ),
+			array( 302, '/some-url', '/new-url', 0, 0, 'Note about new URL' ),
+			array( 301, '/broken-url', '/fixed-url', 0, 0, 'Note about fixed url' ),
+			array( 301, '/reg?ex/\d+/path', '/go/here', 1, 0, 'Note about regex url' ),
 		);
 
 		foreach ( $redirects as $row ) {
@@ -499,6 +499,7 @@ class SRMTestCore extends WP_UnitTestCase {
 				'regex'  => 'is_regex',
 				'code'   => 'http code',
 				'order'  => 'order',
+				'notes'  => 'notes',
 			)
 		);
 


### PR DESCRIPTION
Safe Redirect Manager allows adding notes when creating a redirect via its admin settings page. This update adds support for importing notes via the CLI import command and the `srm_import_file()` function, and for creating a note when using the  `srm_create_redirects()` function.