### PR TITLE
Replace domain when the redirect url is a relative path

### DIFF
--- a/inc/classes/class-srm-redirect.php
+++ b/inc/classes/class-srm-redirect.php
@@ -184,7 +184,7 @@ class SRM_Redirect {
 				}
 
 				// Allow for regex replacement in $redirect_to
-				if ( $enable_regex ) {
+				if ( $enable_regex && ! filter_var( $redirect_to, FILTER_VALIDATE_URL ) ) {
 					$redirect_to = preg_replace( '@' . $redirect_from . '@' . $regex_flag, $redirect_to, $requested_path );
 				}
 

--- a/inc/classes/class-srm-redirect.php
+++ b/inc/classes/class-srm-redirect.php
@@ -186,6 +186,7 @@ class SRM_Redirect {
 				// Allow for regex replacement in $redirect_to
 				if ( $enable_regex && ! filter_var( $redirect_to, FILTER_VALIDATE_URL ) ) {
 					$redirect_to = preg_replace( '@' . $redirect_from . '@' . $regex_flag, $redirect_to, $requested_path );
+					$redirect_to = '/' . ltrim( $redirect_to, '/' );
 				}
 
 				// re-add the query params if they've not already been added by the wildcard


### PR DESCRIPTION
### Description of the Change
We need to add the leading `/` only when the `redirect_to` value is a relative path.
 
Closes #269 

### How to test the Change
#### Scenario One

1. Create a regular expression redirect
2. Redirect from: `(go|bee)\/h{0,}$`
3. Redirect to: `/404-regex`
4. In the CLI run `curl -I http://xu-osp-plugins.local/bee/hhhh`
5. Observe the location header is `http://xu-osp-plugins.local/wp-admin/`

#### Scenario Two

1. Create a regular expression redirect
2. Redirect from: `(go|bee)\/h{0,}$`
3. Redirect to: `http://xu-osp-plugins.local/404-regex`
4. In the CLI run `curl -I http://xu-osp-plugins.local/bee/hhhh`
5. Observe the location header is `http://xu-osp-plugins.local/wp-admin/` (no leading slash)

### Changelog Entry
Fix - Regex redirects without leading `/` are buggy


### Credits
Props @dhanendran 


### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
