### PR TITLE
Indiciate plugin as source of redirect.

### DIFF
--- a/inc/classes/class-srm-redirect.php
+++ b/inc/classes/class-srm-redirect.php
@@ -245,13 +245,12 @@ class SRM_Redirect {
 		header( 'X-Safe-Redirect-Manager: true' );
 		header( 'X-Safe-Redirect-ID: ' . esc_attr( $matched_redirect['redirect_id'] ) );
 
-		// if we have a valid status code, then redirect with it
-		if ( in_array( $matched_redirect['status_code'], srm_get_valid_status_codes(), true ) ) {
-			wp_safe_redirect( $matched_redirect['redirect_to'], $matched_redirect['status_code'] );
-		} else {
-			wp_safe_redirect( $matched_redirect['redirect_to'] );
+		// Use default status code if an invalid value is set.
+		if ( ! in_array( $matched_redirect['status_code'], srm_get_valid_status_codes(), true ) ) {
+			$matched_redirect['status_code'] = apply_filters( 'srm_default_direct_status', 302 );
 		}
 
+		wp_safe_redirect( $matched_redirect['redirect_to'], $matched_redirect['status_code'], 'Safe Redirect Manager' );
 		exit;
 	}
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

Indicate Safe Redirect Manager as the source of redirects.

This replaces the default value of the `$x_redirect_by` parameter in `wp_safe_redirect()` with the plugin's name.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #280

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Check out this branch
2. Create a redirect 
3. Run `curl -I http://your-host-name.local/your-redirect-name` in your command line
4. Ensure the `X-Redirect-By` header is set to `Safe Redirect Manager`

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - Indicate plugin as the source of redirects.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @peterwilsoncc 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
