### PR TITLE
Feature/bump min versions issue 278

### DIFF
--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   php_compatibility:
-    name: PHP minimum 5.6
+    name: PHP minimum 7.4
     runs-on: ubuntu-latest
 
     steps:
@@ -29,4 +29,4 @@ jobs:
         run: composer install
 
       - name: Run PHP Compatibility
-        run: vendor/bin/phpcs safe-redirect-manager.php inc/ -p --standard=PHPCompatibilityWP --extensions=php --runtime-set testVersion 5.6-
+        run: vendor/bin/phpcs safe-redirect-manager.php inc/ -p --standard=PHPCompatibilityWP --extensions=php --runtime-set testVersion 7.4-

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
+        php: ['7.4', '8.0', '8.1']
 
     steps:
     - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "lint-fix": [
       "phpcbf ."
     ],
-    "phpcs:compat": "vendor/bin/phpcs safe-redirect-manager.php inc/ -p --standard=PHPCompatibilityWP --extensions=php --runtime-set testVersion 5.6-"
+    "phpcs:compat": "vendor/bin/phpcs safe-redirect-manager.php inc/ -p --standard=PHPCompatibilityWP --extensions=php --runtime-set testVersion 7.4-"
   },
   "minimum-stability": "dev",
   "config": {

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Safe Redirect Manager ===
 Contributors:      10up, tlovett1, tollmanz, taylorde, jakemgold, danielbachhuber, VentureBeat, jeffpaul
 Tags:              http redirects, redirect manager, url redirection, safe http redirection, multisite redirects, redirects
-Requires at least: 4.6
+Requires at least: 5.7
 Tested up to:      6.0
 Requires PHP:      5.6
 Stable tag:        1.11.1

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors:      10up, tlovett1, tollmanz, taylorde, jakemgold, danielbachhube
 Tags:              http redirects, redirect manager, url redirection, safe http redirection, multisite redirects, redirects
 Requires at least: 5.7
 Tested up to:      6.0
-Requires PHP:      5.6
+Requires PHP:      7.4
 Stable tag:        1.11.1
 License:           GPLv2 or later
 License URI:       http://www.gnu.org/licenses/gpl-2.0.html

--- a/safe-redirect-manager.php
+++ b/safe-redirect-manager.php
@@ -5,7 +5,7 @@
  * Description:       Easily and safely manage HTTP redirects.
  * Version:           1.11.1
  * Requires at least: 5.7
- * Requires PHP:      5.6
+ * Requires PHP:      7.4
  * Author:            10up
  * Author URI:        https://10up.com
  * License:           GPLv2 or later

--- a/safe-redirect-manager.php
+++ b/safe-redirect-manager.php
@@ -4,7 +4,7 @@
  * Plugin URI:        https://wordpress.org/plugins/safe-redirect-manager
  * Description:       Easily and safely manage HTTP redirects.
  * Version:           1.11.1
- * Requires at least: 4.6
+ * Requires at least: 5.7
  * Requires PHP:      5.6
  * Author:            10up
  * Author URI:        https://10up.com


### PR DESCRIPTION
### Description of the Change
Updating WP and php minimum supported versions. Should not affect any functionality outside of workflows and automated testing.

Closes #278

### Changelog Entry
> Bumped minimum WP version from 4.6 to 5.7
> Bumped minimum php version from 5.6 to 7.4
> Bumped phpcs compat script to use 7.4 as test version
> Removed php versions < 7.4 from phpunit tests

### Checklist:
- [x]  WordPress to 5.7
- [x] PHP to 7.4
- [x] Remove any no-longer-needed conditional code for older version support.
- [x] Take a look at adjusting our testing matrices, if applicable.
- [x] Bump the minimums in plugin documentation and header fields.
