### PR TITLE
sorting status code array when additional are added

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -124,7 +124,15 @@ function srm_get_valid_status_codes_data() {
 		array()
 	);
 
-	return $status_codes + $additional_status_codes;
+	if ( empty( $additional_status_codes ) ) {
+		return $status_codes;
+	}
+
+	$status_code_array  = $status_codes + $additional_status_codes;
+
+	ksort( $status_code_array, SORT_NUMERIC );
+
+	return $status_code_array;
 }
 
 /**


### PR DESCRIPTION
## Note

Merge PR #312 before this

### Description of the Change
This PR checks to see if any additional status codes have been added via the `srm_additional_status_codes` filter. If so, it creates the combined array and then sorts it by numeric key before returning it to the dropdown. This is a UX / UI issue, and does not impact any of the functionality already in the plugin.

As you can see below, when additional statuses are added, the list loses the numeric order and can be confusing.
<img width="241" alt="dropdown-before" src="https://user-images.githubusercontent.com/98561/226625711-67f0fcb3-2852-4762-8b57-f4d664f55568.png">

### How to test the Change

1. Add a new HTTP status code via filter
2. Confirm that the code is in numeric order

### Changelog Entry
> Added - New feature
> Changed status code dropdown to be sorted numerically


### Credits
Props @norcross


### Checklist:
- [ x ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ x ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
