### PR TITLE
Ensure we have the `message` array key before trying to use it

### DIFF
--- a/inc/classes/class-srm-redirect.php
+++ b/inc/classes/class-srm-redirect.php
@@ -141,7 +141,7 @@ class SRM_Redirect {
 			$status_code  = $redirect['status_code'];
 			$enable_regex = ( isset( $redirect['enable_regex'] ) ) ? $redirect['enable_regex'] : false;
 			$redirect_id  = $redirect['ID'];
-			$message      = $redirect['message'];
+			$message      = $redirect['message'] ?? '';
 
 			// check if the redirection destination is valid, otherwise just skip it (unless this is a 4xx request)
 			if ( empty( $redirect_to ) && ! in_array( $status_code, array( 403, 404, 410 ), true ) ) {


### PR DESCRIPTION
### Description of the Change

As mentioned [here](https://github.com/10up/safe-redirect-manager/pull/300#issuecomment-1570302851), there is a bug in the newly introduced feature to handle 4xx status codes. This feature introduces an optional message setting, allowing you to enter a custom message that should be shown to the user for certain response codes.

For sites that have existing redirects in place, those are stored in a transient and thus won't have that message field (until those rules are cleared, currently set for 30 days). This will cause PHP warnings to be logged because we try and access an array key that doesn't exist.

This PR fixes that by using the `message` key if it exists and if not, falls back to just an empty string.

### How to test the Change

1. Install the 1.11.1 version of the plugin and add some redirects
2. Upgrade to 2.0.0 version of the plugin
3. Without the code changes here checked out and with debugging turned on, notice PHP warnings are logged when accessing the front-end of your site
4. Check out this PR and notice the warnings go away
5. Ensure redirects still work as expected

### Changelog Entry

> Fixed - Ensure the `message` array key exists before we use it

### Credits

Props @dkotter, @ocean90

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
