### PR TITLE
Fix PHP 8.1 deprecation warnings in `srm_validate_from_url()`.

### DIFF
--- a/inc/classes/class-srm-post-type.php
+++ b/inc/classes/class-srm-post-type.php
@@ -689,13 +689,18 @@ class SRM_Post_Type {
 	 * @return void
 	 */
 	public function srm_validate_from_url() {
-		$_wpnonce = filter_input( INPUT_GET, '_wpnonce', FILTER_SANITIZE_STRING );
+		if ( ! isset( $_GET['_wpnonce'] ) || ! isset( $_GET['from'] ) ) {
+			echo 0;
+			die();
+		}
+
+		$_wpnonce = sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) );
 		if ( ! wp_verify_nonce( $_wpnonce, 'srm-save-redirect-meta' ) ) {
 			echo 0;
 			die();
 		}
 
-		$from = filter_input( INPUT_GET, 'from', FILTER_SANITIZE_STRING );
+		$from = srm_sanitize_redirect_from( wp_unslash( $_GET['from'] ) );
 
 		/**
 		 * SRM treats '/sample-page' and 'sample-page' equally.

--- a/tests/cypress/integration/safe-redirect-manager.test.js
+++ b/tests/cypress/integration/safe-redirect-manager.test.js
@@ -121,6 +121,21 @@ describe('Test redirect rules', () => {
 		cy.verifyEndpointDead('wildcard-403-test/1', 'Test message for a 403 wildcard');
 	});
 
+	it('Can not create a duplicate redirect rule', () => {
+		cy.createRedirectRule(
+			'/duplicate-rule-test/',
+			'/hello-world/',
+			'Rule for testing duplicate rule creation.'
+		);
+
+		cy.visit('/wp-admin/post-new.php?post_type=redirect_rule');
+
+		cy.get('#srm_redirect_rule_from').click().clear().type('/duplicate-rule-test/');
+		cy.get('#srm_redirect_rule_to').click();
+
+		cy.get('.notice-error').should('contain', 'There is an existing redirect with the same Redirect From URL.');
+	});
+
 	it('Can die with a 403 header', () => {
 		cy.createRedirectRule(
 			'/403-test',


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

Replaces the `filter_input( INPUT_GET, '???', FILTER_SANITIZE_STRING );` calls with sanitization functions to avoid deprecation notices in PHP 8.1 or later.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #321

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Install and activate plugin on server running PHP 8.1 or later
2. Ensure debug logging is enabled on your install
3. Visit the add new redirect page wp-admin/post-new.php?post_type=redirect_rule
4. Add a redirect to the Redirect From: field
5. Tab in to the next field, triggering the ajax request to check for existing redirects
6. On `develop` the debug.log file will contain notices
7. On this branch these notices will not be thrown.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Deprecation notices in PHP 8.1 and later.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @peterwilsoncc 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
