### PR TITLE
Added autocomplete to the 'Redirect To: field

### DIFF
--- a/assets/css/redirect.css
+++ b/assets/css/redirect.css
@@ -1,0 +1,54 @@
+.srm-autocomplete__item-title,
+.srm-autocomplete__item-url {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.srm-autocomplete__item-title {
+    font-weight: 500;
+    grid-area: title;
+    margin-bottom: 0.2em;
+    white-space: nowrap;
+}
+
+.srm-autocomplete__item-type {
+    background: #f0f0f0;
+    border-radius: 2px;
+    font-size: 0.9em;
+    grid-area: type;
+    padding: 3px 6px;
+}
+
+.srm-autocomplete__item-url {
+    color: #757575;
+    font-size: 0.9em;
+    grid-area: url;
+    line-height: 1.3;
+    word-break: break-all;
+}
+
+.srm-autocomplete__item {
+    align-items: flex-start;
+    column-gap: 1rem;
+    display: grid;
+    grid-template-areas: "title type"
+        "url type";
+    grid-template-columns: minmax(0, 1fr) auto;
+    padding: 6px 12px;
+}
+
+.srm-autocomplete__item:hover {
+    background-color: #f0f0f0;
+}
+
+.srm-autocomplete__item:hover .srm-autocomplete__item-type {
+    background-color: #fff;
+}
+
+.srm-autocomplete {
+    font-size: 13px;
+    max-width: 360px;
+    padding: 8px 16px;
+}
+
+

--- a/assets/js/redirect.js
+++ b/assets/js/redirect.js
@@ -2,6 +2,7 @@
 	$( function() {
 		const publishBtn = $('#publish');
 		const fromRule = $('#srm_redirect_rule_from');
+		const toRule = $('#srm_redirect_rule_to');
 
 		fromRule.change(function(el) {
 			publishBtn.prop('disabled', true);
@@ -24,9 +25,43 @@
 			});
 		});
 
+		// Show autocomplete for the 'Redirect To:' field.
+		toRule.autocomplete({
+			minLength: 2,
+			classes: {
+				"ui-autocomplete": "srm-autocomplete"
+			},
+			source: function(request, response) {
+				$.ajax({
+					dataType: 'json',
+					url: redirectValidation.ajax_url,
+					data: {
+						term: request.term,
+						action: 'srm_autocomplete',
+						security: redirectValidation.ajax_nonce
+					},
+					success: function(data) {
+						response(data);
+					}
+				});
+			},
+			select: function( event, ui ) {
+				toRule.val( ui.item.relative_url );
+				return false;
+			}
+		})
+		.autocomplete("instance")._renderItem = function (ul, item) {
+			return $(`<li class="srm-autocomplete__item">`)
+				.append(`
+					<div class="srm-autocomplete__item-title">${item.post_title}</div>
+					<div class="srm-autocomplete__item-url">${item.relative_url}</div>
+					<div class="srm-autocomplete__item-type">${item.post_type}</div>
+				`)
+				.appendTo(ul);
+		};
+
 		// Disable the 'Redirect To:' field if a 4xx status code is set.
 		const statusSelect = $('#srm_redirect_rule_status_code');
-		const toRule = $('#srm_redirect_rule_to');
 		const disabledMessage = $('#srm_to_disabled_message');
 
 		statusSelect.change(maybeDisableToRule);

--- a/inc/classes/class-srm-post-type.php
+++ b/inc/classes/class-srm-post-type.php
@@ -49,7 +49,6 @@ class SRM_Post_Type {
 		add_filter( 'default_hidden_columns', array( $this, 'filter_hidden_columns' ), 10, 1 );
 		add_action( 'admin_enqueue_scripts', array( $this, 'load_resources' ), 10, 0 );
 		add_action( 'wp_ajax_srm_validate_from_url', array( $this, 'srm_validate_from_url' ), 10, 0 );
-		add_action( 'wp_ajax_nopriv_srm_autocomplete', array( $this, 'srm_autocomplete' ), 10, 0 );
 		add_action( 'wp_ajax_srm_autocomplete', array( $this, 'srm_autocomplete' ), 10, 0 );
 	}
 
@@ -698,6 +697,11 @@ class SRM_Post_Type {
 	public function srm_autocomplete() {
 		check_ajax_referer( 'srm_autocomplete_nonce', 'security' );
 
+		if ( ! current_user_can( 'read' ) ) {
+			echo wp_json_encode( array() );
+			wp_die();
+		}
+
 		$search_term = isset( $_REQUEST['term'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['term'] ) ) : false;
 		if ( ! $search_term ) {
 			echo wp_json_encode( array() );
@@ -709,6 +713,7 @@ class SRM_Post_Type {
 
 		$query = get_posts(
 			array(
+				'post_type'      => get_post_types(),
 				's'              => $search_term,
 				'posts_per_page' => 5,
 			)

--- a/inc/classes/class-srm-post-type.php
+++ b/inc/classes/class-srm-post-type.php
@@ -697,7 +697,7 @@ class SRM_Post_Type {
 	public function srm_autocomplete() {
 		check_ajax_referer( 'srm_autocomplete_nonce', 'security' );
 
-		if ( ! current_user_can( 'read' ) ) {
+		if ( ! current_user_can( 'srm_manage_redirects' ) ) {
 			echo wp_json_encode( array() );
 			wp_die();
 		}


### PR DESCRIPTION
### Description of the Change

Added a styled autocomplete to the 'Redirect To:' field to make it easier for users to enter URLs. Married the styles of WP's default admin settings page & Gutenberg's autocomplete link popover component.

Closes #41

### How to test the Change

1. With existing posts/pages in place, go to /wp-admin/post-new.php?post_type=redirect_rule
2. In the 'Redirect To:' field, beginning typing to show a list of matched posts

### Changelog Entry

> Added - Added autocomplete to the 'Redirect To:' field


### Credits

Props @bmarshall511 


### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
