### PR TITLE
Removed 'post_status' property from redirects data

### DIFF
--- a/inc/classes/class-srm-wp-cli.php
+++ b/inc/classes/class-srm-wp-cli.php
@@ -15,7 +15,7 @@ class SRM_WP_CLI extends WP_CLI_Command {
 
 	/**
 	 * List all of the currently configured redirects.
-	 * Available fields: 'ID', 'redirect_from', 'redirect_to', 'status_code', 'enable_regex'.
+	 * Available fields: 'ID', 'redirect_from', 'redirect_to', 'status_code', 'enable_regex', 'post_status'.
 	 *
 	 * [--field=<field>]
 	 * : Single field to dipslay, should be one of available fields.
@@ -53,6 +53,7 @@ class SRM_WP_CLI extends WP_CLI_Command {
 			'redirect_to',
 			'status_code',
 			'enable_regex',
+			'post_status',
 		);
 
 		$redirects = srm_get_redirects( array( 'post_status' => 'any' ), true );
@@ -329,6 +330,7 @@ class SRM_WP_CLI extends WP_CLI_Command {
 			'redirect_to',
 			'status_code',
 			'enable_regex',
+			'post_status',
 		];
 
 		$file_name = $assoc_args['filename'] . '.csv';

--- a/inc/classes/class-srm-wp-cli.php
+++ b/inc/classes/class-srm-wp-cli.php
@@ -330,7 +330,6 @@ class SRM_WP_CLI extends WP_CLI_Command {
 			'redirect_to',
 			'status_code',
 			'enable_regex',
-			'post_status',
 		];
 
 		$file_name = $assoc_args['filename'] . '.csv';

--- a/inc/classes/class-srm-wp-cli.php
+++ b/inc/classes/class-srm-wp-cli.php
@@ -15,7 +15,7 @@ class SRM_WP_CLI extends WP_CLI_Command {
 
 	/**
 	 * List all of the currently configured redirects.
-	 * Available fields: 'ID', 'redirect_from', 'redirect_to', 'status_code', 'enable_regex', 'post_status'.
+	 * Available fields: 'ID', 'redirect_from', 'redirect_to', 'status_code', 'enable_regex'.
 	 *
 	 * [--field=<field>]
 	 * : Single field to dipslay, should be one of available fields.
@@ -53,7 +53,6 @@ class SRM_WP_CLI extends WP_CLI_Command {
 			'redirect_to',
 			'status_code',
 			'enable_regex',
-			'post_status',
 		);
 
 		$redirects = srm_get_redirects( array( 'post_status' => 'any' ), true );

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -52,12 +52,15 @@ function srm_get_redirects( $args = array(), $hard = false ) {
 				break;
 			}
 
+			// Check whether include post_status in result
+			$include_post_status_in_result = is_array( $query_args['post_status'] ) || 'any' === $query_args['post_status'];
+
 			foreach ( $redirect_query->posts as $redirect_id ) {
 				if ( count( $redirects ) >= $default_max_redirects ) {
 					break 2;
 				}
 
-				$redirects[] = array(
+				$redirect_data = array(
 					'ID'            => $redirect_id,
 					'redirect_from' => get_post_meta( $redirect_id, '_redirect_rule_from', true ),
 					'redirect_to'   => get_post_meta( $redirect_id, '_redirect_rule_to', true ),
@@ -65,6 +68,12 @@ function srm_get_redirects( $args = array(), $hard = false ) {
 					'message'       => get_post_meta( $redirect_id, '_redirect_rule_message', true ),
 					'enable_regex'  => (bool) get_post_meta( $redirect_id, '_redirect_rule_from_regex', true ),
 				);
+
+				if ( $include_post_status_in_result ) {
+					$redirect_data['post_status'] = get_post_status( $redirect_id );
+				}
+
+				$redirects[] = $redirect_data;
 			}
 
 			$i++;

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -59,7 +59,6 @@ function srm_get_redirects( $args = array(), $hard = false ) {
 
 				$redirects[] = array(
 					'ID'            => $redirect_id,
-					'post_status'   => get_post_status( $redirect_id ),
 					'redirect_from' => get_post_meta( $redirect_id, '_redirect_rule_from', true ),
 					'redirect_to'   => get_post_meta( $redirect_id, '_redirect_rule_to', true ),
 					'status_code'   => (int) get_post_meta( $redirect_id, '_redirect_rule_status_code', true ),


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
To reduce the number of queries in half, we're removing `get_post_status()` from the transient. Its value is always 'publish' and it's not used anywhere, except for being printed in the cli_list

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Partial improve performance for https://github.com/10up/safe-redirect-manager/issues/24

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
I've inserted 10,001 redirects data using CLI and tested performance using Query Monitor plugin

**With `get_post_status()`:**

| Page generation | Peak memory usage | Total time of queries | Number of queries |
| ---------------- | -------------------- | --------------------- | ------------------ |
| 0.7642s - 2.5% of 30s limit | 29.9 MB - 23.4% of 128 MB server limit | 0.1816s | 2056 |

**Without `get_post_status()`:**

| Page generation | Peak memory usage | Total time of queries | Number of queries |
| ---------------- | -------------------- | --------------------- | ------------------ |
| 0.5878s - 2.0% of 30s limit | 18.8 MB - 14.7% of 128 MB server limit | 0.0917s | 1056 |

**Test `srm_get_redirects` function**
- Run `wp safe-redirect-manager list` CLI command to ensure it returns data with any `post_status`
- Run and check return value of `srm_get_redirects()` function without passing any args to ensure it doesn't include `post_status` property 

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @username, @username2, ...


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
