### PR TITLE
Deprecated error in importing fix

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -381,6 +381,11 @@ function srm_import_file( $file, $args ) {
 	// filter arguments
 	$args = apply_filters( 'srm_import_file_args', $args );
 
+	// enable line endings auto detection
+	if ( version_compare( PHP_VERSION, '8.1', '<' ) ) {
+		@ini_set( 'auto_detect_line_endings', true );
+	}
+
 	// open file pointer if $file is not a resource
 	if ( ! is_resource( $file ) ) {
 		$handle = fopen( $file, 'rb' );

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -344,9 +344,6 @@ function srm_import_file( $file, $args ) {
 	// filter arguments
 	$args = apply_filters( 'srm_import_file_args', $args );
 
-	// enable line endings auto detection
-	@ini_set( 'auto_detect_line_endings', true );
-
 	// open file pointer if $file is not a resource
 	if ( ! is_resource( $file ) ) {
 		$handle = fopen( $file, 'rb' );
@@ -365,8 +362,8 @@ function srm_import_file( $file, $args ) {
 
 	while ( ( $row = fgetcsv( $handle ) ) ) {
 		// validate
-		$rule = array_combine( $headers, $row );
-		if ( empty( $rule[ $args['source'] ] ) || empty( $rule[ $args['target'] ] ) ) {
+		$rule = is_array( $row ) ? array_combine( $headers, $row ) : array();
+		if ( empty( $rule ) || empty( $rule[ $args['source'] ] ) || empty( $rule[ $args['target'] ] ) ) {
 			$doing_wp_cli && WP_CLI::warning( 'Skipping - redirection rule is formatted improperly.' );
 			$skipped++;
 			continue;


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
`@ini_set( 'auto_detect_line_endings', true );` removed from csv import script since latest PHP versions manages line endings automatically. 

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #283 

### How to test the Change

- Create a CSV file for SRM importer
- Import from different OS
- It should work as usual

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Deprecated notice


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @dhewer @jayedul 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
