### PR TITLE
Only public post types will be selectable in the autocomplete Redirect To field

### DIFF
--- a/inc/classes/class-srm-post-type.php
+++ b/inc/classes/class-srm-post-type.php
@@ -713,7 +713,11 @@ class SRM_Post_Type {
 
 		$query = get_posts(
 			array(
-				'post_type'      => get_post_types(),
+				'post_type'      => get_post_types(
+					array(
+						'public' => true,
+					)
+				),
 				's'              => $search_term,
 				'posts_per_page' => 5,
 			)


### PR DESCRIPTION
### Description of the Change

Autocomplete will now only display public post types.

Closes #331

### How to test the Change

1. Go to add a new redirect page (/wp-admin/post-new.php?post_type=redirect_rule)
2. Start typing in the "Redirect To" field
3. Only public post types should be displayed

### Changelog Entry

> Fixed - Only public post types will be selectable in the autocomplete Redirect To field


### Credits

Props @bmarshall511 


### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).

