### PR TITLE
Minor update to how autocomplete pulls public post types using is_post_type_viewable

### DIFF
--- a/inc/classes/class-srm-post-type.php
+++ b/inc/classes/class-srm-post-type.php
@@ -713,11 +713,7 @@ class SRM_Post_Type {
 
 		$query = get_posts(
 			array(
-				'post_type'      => get_post_types(
-					array(
-						'public' => true,
-					)
-				),
+				'post_type'      => array_filter( get_post_types(), 'is_post_type_viewable' ),
 				's'              => $search_term,
 				'posts_per_page' => 5,
 			)

--- a/inc/classes/class-srm-post-type.php
+++ b/inc/classes/class-srm-post-type.php
@@ -713,7 +713,16 @@ class SRM_Post_Type {
 
 		$query = get_posts(
 			array(
-				'post_type'      => array_filter( get_post_types(), 'is_post_type_viewable' ),
+				// Get publicly viewable post types, except for redirect_rule.
+				'post_type'      => array_diff_key(
+					array_filter(
+						get_post_types(),
+						'is_post_type_viewable'
+					),
+					array(
+						'redirect_rule' => '',
+					)
+				),
 				's'              => $search_term,
 				'posts_per_page' => 5,
 			)


### PR DESCRIPTION
### Description of the Change

Minor update to how autocomplete pulls public post types using [is_post_type_viewable](https://developer.wordpress.org/reference/functions/is_post_type_viewable/), see https://github.com/10up/safe-redirect-manager/pull/332#discussion_r1248067118

Closes #331 

### How to test the Change

1. Go to add a new redirect page (/wp-admin/post-new.php?post_type=redirect_rule)
2. Start typing in the "Redirect To" field
3. Only public post types should be displayed

### Changelog Entry

> Fixed - Update to how post types are pulled in the autocomplete using is_post_type_viewable

### Credits

Props @bmarshall511, @dkotter 


### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).

