### PR TITLE
Fix raw sql table post meta declaration

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -269,13 +269,13 @@ function srm_create_redirect( $redirect_from, $redirect_to, $status_code = 302, 
 			FROM
 				$wpdb->postmeta AS fromMeta
 			LEFT JOIN
-    			wp_postmeta AS toMeta ON fromMeta.post_id = toMeta.post_id AND toMeta.meta_key = %s
+    			$wpdb->postmeta AS toMeta ON fromMeta.post_id = toMeta.post_id AND toMeta.meta_key = %s
 			LEFT JOIN
-    			wp_postmeta AS statusCodeMeta ON fromMeta.post_id = statusCodeMeta.post_id AND statusCodeMeta.meta_key = %s
+    			$wpdb->postmeta AS statusCodeMeta ON fromMeta.post_id = statusCodeMeta.post_id AND statusCodeMeta.meta_key = %s
 			LEFT JOIN
-    			wp_postmeta AS fromRegexMeta ON fromMeta.post_id = fromRegexMeta.post_id AND fromRegexMeta.meta_key = %s
+    			$wpdb->postmeta AS fromRegexMeta ON fromMeta.post_id = fromRegexMeta.post_id AND fromRegexMeta.meta_key = %s
 			LEFT JOIN
-   				wp_postmeta AS notesMeta ON fromMeta.post_id = notesMeta.post_id AND notesMeta.meta_key = %s
+   				$wpdb->postmeta AS notesMeta ON fromMeta.post_id = notesMeta.post_id AND notesMeta.meta_key = %s
 			WHERE
     			fromMeta.meta_key = %s AND fromMeta.meta_value = %s",
 			'_redirect_rule_to',


### PR DESCRIPTION
### Description of the Change
In this pull request, I have made a minor modification to how the `postmeta` table is referenced. Previously, the `postmeta` table was directly referenced by its name (e.g., `wp_postmeta`). I have modified this reference to use the `$wpdb->postmeta` variable, which is a standard practice in WordPress to ensure better compatibility with custom WordPress installations and multi-site environments.

**Advantages:**
- Improved compatibility with custom WordPress installations.
- Better support for multi-site environments.
- Alignment with WordPress best practices and standards.

### How to test the Change
1. Install the plugin with custom database prefix.
2. Set up some redirections using the plugin or import redirection with csv file.
3. Verify that the redirections are working correctly.

### Changelog Entry

> Changed - Improved reference to the `postmeta` table for better WordPress compatibility.

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.