### PR TITLE
Document filter for changing default redirect status code

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ This should be a path (i.e. `/test`) or a URL (i.e. `http://example.com/wp/test`
 * Developers can use `srm_additional_status_codes` filter to add status codes if needed.
 * Rules set with 403 and 410 status codes are handled by applying the HTTP status code and render the default WordPress `wp_die` screen with an optional message.
 * Rules set with a 404 status code will apply the status code and render the 404 template.
+* Browsers heavily cache 301 (permanently moved) redirects. It's recommended to test your permanent redirects using the 302 (temporarily moved) status code before changing them to 301 permanently moved.
 
 ## Filters
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,22 @@ This should be a path (i.e. `/test`) or a URL (i.e. `http://example.com/wp/test`
 
 ## Filters
 
+### Default redirect status code
+
+The default redirect HTTP status code can be changed using the `srm_default_direct_status` filter.
+
+```php
+add_filter(
+	'srm_default_direct_status',
+	/**
+	 * Set the default redirect status to 301 (Moved Permanently).
+	 */
+	function() {
+		return 301;
+	}
+);
+```
+
 ### Redirect loops detection
 
 By default redirect loop detection is disabled. To prevent redirect loops you can filter `srm_check_for_possible_redirect_loops`.

--- a/readme.txt
+++ b/readme.txt
@@ -50,6 +50,7 @@ This should be a path (i.e. `/test`) or a URL (i.e. `http://example.com/wp/test`
 * Developers can use `srm_additional_status_codes` filter to add status codes if needed.
 * Rules set with 403 and 410 status codes are handled by applying the HTTP status code and render the default WordPress `wp_die` screen with an optional message.
 * Rules set with a 404 status code will apply the status code and render the 404 template.
+* Browsers heavily cache 301 (permanently moved) redirects. It's recommended to test your permanent redirects using the 302 (temporarily moved) status code before changing them to 301 permanently moved.
 
 == Changelog ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -52,6 +52,10 @@ This should be a path (i.e. `/test`) or a URL (i.e. `http://example.com/wp/test`
 * Rules set with a 404 status code will apply the status code and render the 404 template.
 * Browsers heavily cache 301 (permanently moved) redirects. It's recommended to test your permanent redirects using the 302 (temporarily moved) status code before changing them to 301 permanently moved.
 
+=== Developer Documentation ===
+
+Safe Redirect Manager includes a number of actions and filters developers can make use of. These are documented on the [Safe Redirect Manager developer documentation](http://10up.github.io/safe-redirect-manager/) micro-site.
+
 == Changelog ==
 
 = 2.1.1 - 2024-01-08 =


### PR DESCRIPTION
### Description of the Change
Documentation change:

* provide example for `srm_default_direct_status` filter in readme.MD (GitHub default)
* link to developer docs in readme.txt (WordPress.org default)
* warn of browser caching for permanent redirects

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #364

### How to test the Change

N/A Docs change only.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - Provide example for modifying the default redirect status code
> Added - Link to developer docs from WordPress.org


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @peterwilsoncc, @jeffpaul, @JosVelasco


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
