### PR TITLE
Issue #367 - Show error instead of warning when it is a redirect loop

### DIFF
--- a/inc/classes/class-srm-post-type.php
+++ b/inc/classes/class-srm-post-type.php
@@ -244,8 +244,8 @@ class SRM_Post_Type {
 
 				if ( ! empty( $cycle_source ) ) {
 					?>
-					<div class="notice notice-warning">
-						<p><?php esc_html_e( 'Safe Redirect Manager Warning: The following redirects with the "Redirect To" value have created redirect chain/loops.', 'safe-redirect-manager' ); ?></p>
+					<div class="notice notice-error">
+						<p><?php esc_html_e( 'Safe Redirect Manager Error: The following redirects with the "Redirect To" value have created redirect loops.', 'safe-redirect-manager' ); ?></p>
 						<ul style="list-style: inside;">
 							<?php foreach ( $paths as $path ) : ?>
 								<li>


### PR DESCRIPTION
### Description of the Change

When we have loop error we have an error message.

Previously it was looking like this 
![image](https://github.com/10up/safe-redirect-manager/assets/19459637/daf1d64a-d407-4eb6-b627-7063b551face)

Now it is looking like this
![image](https://github.com/10up/safe-redirect-manager/assets/19459637/80ad38fd-abc7-4851-aa3b-a97a9af30e1b)

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #367 

### How to test the Change
- Let's say you have a page `https://example.com/abc/`
- You want to set redirection for that page.
- Go to WP Admin --> Tools --> Safe Redirection Manager --> Create Redirection Rule
- Add `/abc/` for "Redirect From" and set `https://example.com/abc/` for "Redirect To"
- Hit Publish

### Changelog Entry

> Changed - Warning message to error message after loops are detected.



### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @aaemnnosttv @Sidsector9 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
