### PR TITLE
Issue #366 - Make URL validation on input event instead of change event

### DIFF
--- a/assets/js/redirect.js
+++ b/assets/js/redirect.js
@@ -3,26 +3,15 @@
 		const publishBtn = $('#publish');
 		const fromRule = $('#srm_redirect_rule_from');
 		const toRule = $('#srm_redirect_rule_to');
+		let timer = 0;
+		let currentRequest = null;
 
-		fromRule.change(function(el) {
+		fromRule.keyup(function(el) {
 			publishBtn.prop('disabled', true);
-			$.get(
-				window.ajaxurl,
-				{
-					action: 'srm_validate_from_url',
-					from: fromRule.val(),
-					_wpnonce: $('#srm_redirect_nonce').val()
-				}
-			).done(function( data ) {
-				if ( '1' === data ) {
-					$('#message').html( '' ).hide();
-					publishBtn.prop('disabled', false);
-				} else if ( '0' === data ) {
-					$('#message').html( `<p>${redirectValidation.urlError}</p>` ).show();
-				} else {
-					$('#message').html( `<p>${redirectValidation.fail.replace( '%s', data )}</p>` ).show();
-				}
-			});
+			if (timer) {
+				clearTimeout(timer); // Clear the time after function execution.
+			}
+			timer = setTimeout( validateUrl, 850); // Wait for 0.85 seconds.
 		});
 
 		// Show autocomplete for the 'Redirect To:' field.
@@ -94,6 +83,36 @@
 				message.prop('disabled', 'disabled');
 				messageContainer.hide();
 			}
+		}
+
+		/**
+		 * Validate URL for 'Redirect From' field.
+		 */
+		function validateUrl() {
+			currentRequest = $.ajax({
+				url: window.ajaxurl,
+				method : 'GET',
+				data : {
+					action: 'srm_validate_from_url',
+					from: fromRule.val(),
+					_wpnonce: $('#srm_redirect_nonce').val()
+				},
+				beforeSend : function() {
+					if ( currentRequest != null ) {
+						currentRequest.abort();
+					}
+				},
+				success: function( data ) {
+					if ( '1' === data ) {
+						$('#message').html( '' ).hide();
+						publishBtn.prop('disabled', false);
+					} else if ( '0' === data ) {
+						$('#message').html( `<p>${redirectValidation.urlError}</p>` ).show();
+					} else {
+						$('#message').html( `<p>${redirectValidation.fail.replace( '%s', data )}</p>` ).show();
+					}
+				}
+			});
 		}
 
 	} );

--- a/assets/js/redirect.js
+++ b/assets/js/redirect.js
@@ -6,7 +6,7 @@
 		let timer = 0;
 		let currentRequest = null;
 
-		fromRule.keyup(function(el) {
+		fromRule.on('input',function(el) {
 			publishBtn.prop('disabled', true); // Disable submit button.
 			fromRule.addClass('ui-autocomplete-loading'); // Add loader.
 			if (timer) {
@@ -99,16 +99,15 @@
 					_wpnonce: $('#srm_redirect_nonce').val()
 				},
 				beforeSend : function() {
-					if ( currentRequest != null ) {
+					if ( currentRequest !== null ) {
 						currentRequest.abort();
 					}
 				},
 				success: function( data ) {
 
 					// Remove loader.
-					if ( fromRule.hasClass( 'ui-autocomplete-loading' ) ) {
-						fromRule.removeClass( 'ui-autocomplete-loading' );
-					}
+					fromRule.removeClass( 'ui-autocomplete-loading' );
+
 					if ( '1' === data ) {
 						$('#message').html( '' ).hide();
 						publishBtn.prop('disabled', false);

--- a/assets/js/redirect.js
+++ b/assets/js/redirect.js
@@ -7,7 +7,8 @@
 		let currentRequest = null;
 
 		fromRule.keyup(function(el) {
-			publishBtn.prop('disabled', true);
+			publishBtn.prop('disabled', true); // Disable submit button.
+			fromRule.addClass('ui-autocomplete-loading'); // Add loader.
 			if (timer) {
 				clearTimeout(timer); // Clear the time after function execution.
 			}
@@ -103,6 +104,11 @@
 					}
 				},
 				success: function( data ) {
+
+					// Remove loader.
+					if ( fromRule.hasClass( 'ui-autocomplete-loading' ) ) {
+						fromRule.removeClass( 'ui-autocomplete-loading' );
+					}
 					if ( '1' === data ) {
 						$('#message').html( '' ).hide();
 						publishBtn.prop('disabled', false);


### PR DESCRIPTION
### Description of the Change
Changed event for "Redirect From" field for URL validation.

- Previously it was on a `change` event, so validation was not happening unless we click out of the text field. Because of that publish button disabling was irregular and confusing.
- So made it on `keyup` event and added ajax abort to avoid simultaneous requests.
- Also added a typing wait time of 850 ms so when user stops typing, then URL validation will happen.
- Based on this validation process, disabling/enabling submit button became regular now.
- Also added a loding icon when user start typing, so that they know something is happening.

Video for better understanding for above bullet points https://somup.com/cZnTI6pzGz

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #366

### How to test the Change

- Go to WP admin --> Tools --> Safe Redirect Manager
- Click "Create Redirect Rule"
- Start typing into "Redirect From" and stop typing
- Remove some characters and stop
- Observe the submit button active/inactive state

### Changelog Entry
> Changed - URL validation check on "input" event for "Redirect From" field



### Credits
@BhargavBhandari90, @peterwilsoncc


### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
