### PR TITLE
Fix PHP warning when calling the "wp safe-redirect-manager list" command

### DIFF
--- a/inc/classes/class-srm-wp-cli.php
+++ b/inc/classes/class-srm-wp-cli.php
@@ -58,7 +58,7 @@ class SRM_WP_CLI extends WP_CLI_Command {
 
 		$redirects = srm_get_redirects( array( 'post_status' => 'any' ), true );
 		$redirects = array_map(
-			function( &$item ) use ( $assoc_args ) {
+			function( $item ) use ( $assoc_args ) {
 				if ( 'table' === $assoc_args['format'] ) {
 					$item['enable_regex'] = $item['enable_regex'] ? 'true' : 'false';
 				} else {


### PR DESCRIPTION
### Description of the Change
Fixed the following PHP warning when running the `wp safe-redirect-manager list` CLI command

```
[25-Apr-2024 14:37:37 UTC] PHP Warning:  SRM_WP_CLI::{closure}(): Argument #1 ($item) must be passed by reference, value given in /var/www/html/wp-content/plugins/safe-redirect-manager/inc/classes/class-srm-wp-cli.php on line 60
[25-Apr-2024 14:37:37 UTC] PHP Stack trace:
[25-Apr-2024 14:37:37 UTC] PHP   1. {main}() /usr/local/bin/wp:0
[25-Apr-2024 14:37:37 UTC] PHP   2. include() /usr/local/bin/wp:4
[25-Apr-2024 14:37:37 UTC] PHP   3. include() phar:///usr/local/bin/wp/php/boot-phar.php:20
[25-Apr-2024 14:37:37 UTC] PHP   4. WP_CLI\bootstrap() phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/wp-cli.php:32
[25-Apr-2024 14:37:37 UTC] PHP   5. WP_CLI\Bootstrap\LaunchRunner->process($state = class WP_CLI\Bootstrap\BootstrapState { private $state = ['context_manager' => class WP_CLI\ContextManager { ... }] }) phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/bootstrap.php:83
[25-Apr-2024 14:37:37 UTC] PHP   6. WP_CLI\Runner->start() phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Bootstrap/LaunchRunner.php:28
[25-Apr-2024 14:37:37 UTC] PHP   7. WP_CLI\Runner->run_command_and_exit($help_exit_warning = *uninitialized*) phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:1269
[25-Apr-2024 14:37:37 UTC] PHP   8. WP_CLI\Runner->run_command($args = [0 => 'safe-redirect-manager', 1 => 'list'], $assoc_args = [], $options = *uninitialized*) phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:454
[25-Apr-2024 14:37:37 UTC] PHP   9. WP_CLI\Dispatcher\Subcommand->invoke($args = [], $assoc_args = [], $extra_args = []) phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:431
[25-Apr-2024 14:37:37 UTC] PHP  10. call_user_func:{phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/Subcommand.php:491}($callback = class Closure { public $static = ['callable' => [...]]; public $parameter = ['$args' => '<required>', '$assoc_args' => '<required>'] }, ...$args = variadic([])) phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/Subcommand.php:491
[25-Apr-2024 14:37:37 UTC] PHP  11. WP_CLI\Dispatcher\CommandFactory::WP_CLI\Dispatcher\{closure:phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php:97-104}($args = [], $assoc_args = []) phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/Subcommand.php:491
[25-Apr-2024 14:37:37 UTC] PHP  12. call_user_func:{phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php:100}($callback = [0 => class SRM_WP_CLI {  }, 1 => 'cli_list'], ...$args = variadic([])) phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php:100
[25-Apr-2024 14:37:37 UTC] PHP  13. SRM_WP_CLI->cli_list($args = [], $assoc_args = []) phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php:100
[25-Apr-2024 14:37:37 UTC] PHP  14. array_map($callback = class Closure { public $static = ['assoc_args' => [...]]; public $this = class SRM_WP_CLI {  }; public $parameter = ['&$item' => '<required>'] }, $array = [0 => ['ID' => 5415, 'redirect_from' => '/test', 'redirect_to' => '/testing', 'status_code' => 302, 'message' => '', 'enable_regex' => FALSE, 'force_https' => '1', 'post_status' => 'publish']]) /var/www/html/wp-content/plugins/safe-redirect-manager/inc/classes/class-srm-wp-cli.php:60
```

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #377

### How to test the Change
1. Activate the Safe Redirect Manager plugin
2. Add a redirect
3. Run the `wp safe-redirect-manager list` CLI command and verify the output
4. Verify that there is no PHP warning in the debug log file

### Changelog Entry
> Fixed - PHP warning when running the "wp safe-redirect-manager list" CLI command.



### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @kmgalanakis


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
