### PR TITLE
Allow regular expression parsing if the redirect target is a valid URL

### DIFF
--- a/inc/classes/class-srm-redirect.php
+++ b/inc/classes/class-srm-redirect.php
@@ -176,8 +176,10 @@ class SRM_Redirect {
 
 			// check if requested path is the same as the redirect from path
 			if ( $enable_regex ) {
+				// for regexes, check whether the requested path matches the $redirect_from regular expression
 				$match_query_params = false;
 				$matched_path       = preg_match( '@' . $redirect_from . '@' . $regex_flag, $requested_path );
+				// and then return the matching path
 			} else {
 				if ( $case_insensitive ) {
 					$redirect_from = strtolower( $redirect_from );
@@ -207,6 +209,8 @@ class SRM_Redirect {
 				}
 			}
 
+			// If the requested path matches a redirect rule...
+			// this variable is not used after this boolean.
 			if ( $matched_path ) {
 				/**
 				 * Whitelist redirect host
@@ -223,9 +227,14 @@ class SRM_Redirect {
 				}
 
 				// Allow for regex replacement in $redirect_to
-				if ( $enable_regex && ! filter_var( $redirect_to, FILTER_VALIDATE_URL ) ) {
+				if ( $enable_regex ) {
 					$redirect_to = preg_replace( '@' . $redirect_from . '@' . $regex_flag, $redirect_to, $requested_path );
-					$redirect_to = '/' . ltrim( $redirect_to, '/' );
+
+					// If $redirect_to does not look like a valid URL,
+					// assume that it needs to be turned into a path relative to root with a leading slash.
+					if ( ! filter_var( $redirect_to, FILTER_VALIDATE_URL ) ) {
+						$redirect_to = '/' . ltrim( $redirect_to, '/' );
+					}
 				}
 
 				// re-add the query params if they've not already been added by the wildcard

--- a/tests/php/test-core.php
+++ b/tests/php/test-core.php
@@ -690,25 +690,35 @@ class SRMTestCore extends WP_UnitTestCase {
 	 */
 	public function testRedirectToExternalDomainWithNonSubstitutingRegex269() {
 		$_SERVER['REQUEST_URI'] = '/be/hhhh';
-		$redirected             = true;
+		$redirect_from          = '(go|be)\/h{0,}$';
 		$redirect_to            = 'http://xu-osp-plugins.local/404-regex';
-		$expected               = 'http://xu-osp-plugins.local/404-regex';
+		$status                 = 301;
+		$use_regex              = true;
 
-		srm_create_redirect( '(go|be)\/h{0,}$', $redirect_to, 301, true );
+		$expected_redirect = 'http://xu-osp-plugins.local/404-regex';
+		$expected_status   = 301;
+
+		$actual_request = '';
+		$actual_redirect = '';
+		$actual_status   = 0;
+
+		srm_create_redirect( $redirect_from, $redirect_to, $status, $use_regex );
 
 		add_action(
 			'srm_do_redirect',
-			function( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected, &$expected ) {
-				if ( $redirected_to === $expected ) {
-					$redirected = true;
-				}
+			function( $requested_path, $redirected_to, $status_code ) use ( &$actual_request, &$actual_redirect, &$actual_status ) {
+				$actual_request = $requested_path;
+				$actual_redirect = $redirected_to;
+				$actual_status = $status_code;
 			},
 			10,
 			3
 		);
 
 		SRM_Redirect::factory()->maybe_redirect();
-		$this->assertTrue( $redirected, 'Expected that a non-substituting regular expression would trigger a redirect to http://xu-osp-plugins.local/404-regex, but instead redirected to ' . $redirect_to );
+		$this->assertSame( $_SERVER['REQUEST_URI'], $actual_request, 'The requested path does not meet the expectation' );
+		$this->assertSame( $expected_redirect, $actual_redirect, 'The redirect destination does not meet the expectation' );
+		$this->assertSame( $expected_status, $actual_status, 'The redirect status does npt meet the expectation.' );
 	}
 
 	/**
@@ -719,28 +729,35 @@ class SRMTestCore extends WP_UnitTestCase {
 	 */
 	public function testRedirectToExternalDomainWithSubstitutingRegex380() {
 		$_SERVER['REQUEST_URI'] = '/test/1234';
-		$redirected             = true;
 		$redirect_from          = '/test/(.*)';
 		$redirect_to            = 'http://example.org/$1';
-		$expected               = 'http://example.org/1234';
+		$status                 = 301;
+		$use_regex              = true;
 
-		srm_create_redirect( $redirect_from, $redirect_to, 301, true );
+		$expected_redirect = 'http://example.org/1234';
+		$expected_status   = 301;
+
+		$actual_request = '';
+		$actual_redirect = '';
+		$actual_status   = 0;
+
+		srm_create_redirect( $redirect_from, $redirect_to, $status, $use_regex );
 
 		add_action(
 			'srm_do_redirect',
-			function( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected, &$expected ) {
-				if ( $redirected_to === $expected ) {
-					$redirected = true;
-				} else {
-					$redirect_to = $redirected_to;
-				}
+			function( $requested_path, $redirected_to, $status_code ) use ( &$actual_request, &$actual_redirect, &$actual_status ) {
+				$actual_request = $requested_path;
+				$actual_redirect = $redirected_to;
+				$actual_status = $status_code;
 			},
 			10,
 			3
 		);
 
 		SRM_Redirect::factory()->maybe_redirect();
-		$this->assertTrue( $redirected, 'Expected that a substituting regular expression would trigger a redirect to http://example.org/1234, but instead redirected to ' . $redirect_to );
+		$this->assertSame( $_SERVER['REQUEST_URI'], $actual_request, 'The requested path does not meet the expectation' );
+		$this->assertSame( $expected_redirect, $actual_redirect, 'The redirect destination does not meet the expectation' );
+		$this->assertSame( $expected_status, $actual_status, 'The redirect status does npt meet the expectation.' );
 	}
 
 	/**
@@ -751,27 +768,34 @@ class SRMTestCore extends WP_UnitTestCase {
 	 */
 	public function testRedirectToPathWithSubstitutingRegex380() {
 		$_SERVER['REQUEST_URI'] = '/test/1234';
-		$redirected             = true;
 		$redirect_from          = '/test/(.*)';
 		$redirect_to            = '/result/$1';
-		$expected               = '/result/1234';
+		$status                 = 301;
+		$use_regex              = true;
 
-		srm_create_redirect( $redirect_from, $redirect_to, 301, true );
+		$expected_redirect = '/result/1234';
+		$expected_status   = 301;
+
+		$actual_request = '';
+		$actual_redirect = '';
+		$actual_status   = 0;
+
+		srm_create_redirect( $redirect_from, $redirect_to, $status, $use_regex );
 
 		add_action(
 			'srm_do_redirect',
-			function( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected, &$expected ) {
-				if ( $redirected_to === $expected ) {
-					$redirected = true;
-				} else {
-					$redirect_to = $redirected_to;
-				}
+			function( $requested_path, $redirected_to, $status_code ) use ( &$actual_request, &$actual_redirect, &$actual_status ) {
+				$actual_request = $requested_path;
+				$actual_redirect = $redirected_to;
+				$actual_status = $status_code;
 			},
 			10,
 			3
 		);
 
 		SRM_Redirect::factory()->maybe_redirect();
-		$this->assertTrue( $redirected, 'Expected that a substituting regular expression would trigger a redirect to /result/1234, but instead redirected to ' . $redirect_to );
+		$this->assertSame( $_SERVER['REQUEST_URI'], $actual_request, 'The requested path does not meet the expectation' );
+		$this->assertSame( $expected_redirect, $actual_redirect, 'The redirect destination does not meet the expectation' );
+		$this->assertSame( $expected_status, $actual_status, 'The redirect status does npt meet the expectation.' );
 	}
 }

--- a/tests/php/test-core.php
+++ b/tests/php/test-core.php
@@ -698,7 +698,7 @@ class SRMTestCore extends WP_UnitTestCase {
 		$expected_redirect = 'http://xu-osp-plugins.local/404-regex';
 		$expected_status   = 301;
 
-		$actual_request = '';
+		$actual_request  = '';
 		$actual_redirect = '';
 		$actual_status   = 0;
 
@@ -707,9 +707,9 @@ class SRMTestCore extends WP_UnitTestCase {
 		add_action(
 			'srm_do_redirect',
 			function( $requested_path, $redirected_to, $status_code ) use ( &$actual_request, &$actual_redirect, &$actual_status ) {
-				$actual_request = $requested_path;
+				$actual_request  = $requested_path;
 				$actual_redirect = $redirected_to;
-				$actual_status = $status_code;
+				$actual_status   = $status_code;
 			},
 			10,
 			3
@@ -737,7 +737,7 @@ class SRMTestCore extends WP_UnitTestCase {
 		$expected_redirect = 'http://example.org/1234';
 		$expected_status   = 301;
 
-		$actual_request = '';
+		$actual_request  = '';
 		$actual_redirect = '';
 		$actual_status   = 0;
 
@@ -746,9 +746,9 @@ class SRMTestCore extends WP_UnitTestCase {
 		add_action(
 			'srm_do_redirect',
 			function( $requested_path, $redirected_to, $status_code ) use ( &$actual_request, &$actual_redirect, &$actual_status ) {
-				$actual_request = $requested_path;
+				$actual_request  = $requested_path;
 				$actual_redirect = $redirected_to;
-				$actual_status = $status_code;
+				$actual_status   = $status_code;
 			},
 			10,
 			3
@@ -776,7 +776,7 @@ class SRMTestCore extends WP_UnitTestCase {
 		$expected_redirect = '/result/1234';
 		$expected_status   = 301;
 
-		$actual_request = '';
+		$actual_request  = '';
 		$actual_redirect = '';
 		$actual_status   = 0;
 
@@ -785,9 +785,9 @@ class SRMTestCore extends WP_UnitTestCase {
 		add_action(
 			'srm_do_redirect',
 			function( $requested_path, $redirected_to, $status_code ) use ( &$actual_request, &$actual_redirect, &$actual_status ) {
-				$actual_request = $requested_path;
+				$actual_request  = $requested_path;
 				$actual_redirect = $redirected_to;
-				$actual_status = $status_code;
+				$actual_status   = $status_code;
 			},
 			10,
 			3


### PR DESCRIPTION
### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

#269 reported a bug in the handling of regex redirects with a URL target: the URLs were being prefixed with a `/`.

#279 fixed #269 by excluding the section of code that prepends URLs with `/` from being applied if the redirect target was a valid URL:

https://github.com/10up/safe-redirect-manager/blob/cb1c04513b75736a0938208c5837b3ce51abdcba/inc/classes/class-srm-redirect.php#L225-L229

Unfortunately, this _also_ excluded the code that _applies_ the regular expression to the redirect target URL. If the redirect target was a URL, the final `preg_replace` was no longer applied.

This fix separates the prefix-with-`/` behavior from regex parsing by separating the conditionals.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes https://github.com/10up/safe-redirect-manager/issues/380

### How to test the Change

Test cases, all with regular expressions:
- from `/test/(.*)` to `https://example.org/$1` with `/test/1234` should go to `https://example.org/1234/` (#380)
- from `/test/(.*)` to `/$1` with `/test/1234/` should go to `/1234/`
- from `(go|be)\/h{0,}$` to `/404-regex` with `/be/hhhh` should go to `/404-regex` (#269)
- from `(go|be)\/h{0,}$` to `http://xu-osp-plugins.local/404-regex` with `/be/hhhh` should go to `http://xu-osp-plugins.local/404-regex` (#269)

### Changelog Entry

<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Fixed - Allows use of full URLs as redirect targets when using absolute URLs (#395 for #380)

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @benlk @peterwilsoncc 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
