### PR TITLE
Prevent undefined property warnings during search.

### DIFF
--- a/inc/classes/class-srm-post-type.php
+++ b/inc/classes/class-srm-post-type.php
@@ -22,7 +22,7 @@ class SRM_Post_Type {
 	 *
 	 * @var string
 	 */
-	private $redirect_search_term;
+	private $redirect_search_term = false;
 
 	/**
 	 * Sets up redirect manager
@@ -144,7 +144,8 @@ class SRM_Post_Type {
 			$search_term_like = '%' . $wpdb->esc_like( $search_term ) . '%';
 
 			$query->set( 's', $this->redirect_search_term );
-			unset( $this->redirect_search_term );
+			// Restore search term to a false value to prevent modifying the query again.
+			$this->redirect_search_term = false;
 
 			$clauses['distinct'] = 'DISTINCT';
 


### PR DESCRIPTION
### Description of the Change
To avoid modifying the search query clause twice, the redirect term is discarded after the WHERE clause is generated.

The use of `unset()` triggers warnings as the second call to the filter is attempting to access an undefined property. This changes the code to set the search term to false to prevent the second and subsequent runs of the filter.

Closes #399

### How to test the Change

1. Enable all logging of errors in your wp-config.php file:
   ```php
   define( 'WP_DEBUG', true );
   define( 'WP_DEBUG_DISPLAY', true );
   define( 'WP_DEBUG_LOG', true );
   ```
2. Configure the site to run on PHP 8.0+ (this is when the error level became a warning)
3. Create a redirect
4. Search redirects
5. Check the logs to ensure a warning is not recorded. On single site installs the log is located in the default `wp-content` folder.
   * on `trunk` a warning will be thrown
   * on this branch no warning will be thrown


### Changelog Entry
> Fixed - Prevent undefined property warnings when searching redirects.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @chermant, @Sidsector9, @peterwilsoncc 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
