### PR TITLE
Ensure the `add_new` and `add_new_item` labels are the same

### DIFF
--- a/inc/classes/class-srm-post-type.php
+++ b/inc/classes/class-srm-post-type.php
@@ -602,8 +602,8 @@ class SRM_Post_Type {
 		$redirect_labels = array(
 			'name'               => esc_html_x( 'Safe Redirect Manager', 'post type general name', 'safe-redirect-manager' ),
 			'singular_name'      => esc_html_x( 'Redirect', 'post type singular name', 'safe-redirect-manager' ),
-			'add_new'            => _x( 'Create Redirect Rule', 'redirect rule', 'safe-redirect-manager' ),
-			'add_new_item'       => esc_html__( 'Safe Redirect Manager', 'safe-redirect-manager' ),
+			'add_new'            => esc_html_x( 'Create Redirect Rule', 'redirect rule', 'safe-redirect-manager' ),
+			'add_new_item'       => esc_html__( 'Create Redirect Rule', 'safe-redirect-manager' ),
 			'edit_item'          => esc_html__( 'Edit Redirect Rule', 'safe-redirect-manager' ),
 			'new_item'           => esc_html__( 'New Redirect Rule', 'safe-redirect-manager' ),
 			'all_items'          => esc_html__( 'Safe Redirect Manager', 'safe-redirect-manager' ),


### PR DESCRIPTION
### Description of the Change

In testing on WP 6.7, the Add New button for the Safe Redirect Manager post type is showing as `Safe Redirect Manager` instead of `Create Redirect Rule`. This causes an E2E failure and also doesn't make much sense, since this button shows right next to the title which is also Safe Redirect Manager.

Seems WP 6.7 changed something around the `add_new` and `add_new_item` labels so this PR ensures our post type uses the same text for both.

**Before on WP 6.7:**

<img width="476" alt="Settings page before fix" src="https://github.com/user-attachments/assets/6dc6225c-3542-4c11-ba88-f1827014fc1c">

**After on WP 6.7 (and older):**

<img width="509" alt="Settings page after fix" src="https://github.com/user-attachments/assets/4a79533e-43b6-4419-823b-8506fb49d610">

### How to test the Change

1. Go to the Safe Redirect Manager page under Tools
2. Ensure the button shown at the top says `Create Redirect Rule`
3. Test on both WP 6.7 and 6.6

### Changelog Entry

> Fixed - Ensure the add new button shows proper text

### Credits

Props @dkotter, @jeffpaul 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
