### PR TITLE
adding author ID as a variable

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -232,11 +232,12 @@ function srm_check_for_possible_redirect_loops() {
  * @param string $post_status Post status
  * @param int    $menu_order Menu order
  * @param string $notes Notes
+ * @param int    $author_id Author ID
  * @since 1.8
  * @uses wp_insert_post, update_post_meta
  * @return int|WP_Error
  */
-function srm_create_redirect( $redirect_from, $redirect_to, $status_code = 302, $enable_regex = false, $post_status = 'publish', $menu_order = 0, $notes = '' ) {
+function srm_create_redirect( $redirect_from, $redirect_to, $status_code = 302, $enable_regex = false, $post_status = 'publish', $menu_order = 0, $notes = '', $author_id = 1 ) {
 	global $wpdb;
 
 	$sanitized_redirect_from = srm_sanitize_redirect_from( $redirect_from );
@@ -246,6 +247,7 @@ function srm_create_redirect( $redirect_from, $redirect_to, $status_code = 302, 
 	$sanitized_post_status   = sanitize_key( $post_status );
 	$sanitized_menu_order    = absint( $menu_order );
 	$sanitized_notes         = sanitize_text_field( $notes );
+	$sanitized_author_id     = absint( $author_id );
 
 	// check and make sure no parameters are empty or invalid after sanitation
 	if ( empty( $sanitized_redirect_from ) || empty( $sanitized_redirect_to ) ) {
@@ -291,9 +293,8 @@ function srm_create_redirect( $redirect_from, $redirect_to, $status_code = 302, 
 	$post_args = array(
 		'post_type'   => 'redirect_rule',
 		'post_status' => $sanitized_post_status,
-		'post_author' => 1,
+		'post_author' => $sanitized_author_id,
 		'menu_order'  => $sanitized_menu_order,
-
 	);
 
 	if ( $existing_redirect ) {
@@ -323,8 +324,6 @@ function srm_create_redirect( $redirect_from, $redirect_to, $status_code = 302, 
 
 	return $post_id;
 }
-
-
 
 /**
  * Sanitize redirect to path


### PR DESCRIPTION
### Description of the Change
This PR is a small change that adds an additional argument for the author ID (`$author_id`) to the `srm_create_redirect` function. currently, the author ID is hard-coded to a value of 1, whether or not that author exists at all. when a redirect is created via the admin UI, the current user ID is used as the author ID, so i'd like to also be able to set the author (current or otherwise) when using this function outside of the plugin. the function sets the default to 1, so this would not impact any current implementations.

### How to test the Change
1. Pass an ID as the last argument to `srm_create_redirect` with a default value of 1
2. View the author ID stored in the database

### Changelog Entry
> Added - New feature
> adding additional variable for author ID

### Credits
Props @norcross 

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
