### PR TITLE
Ensure redirects are not flagged as their own duplicate.

### DIFF
--- a/assets/js/redirect.js
+++ b/assets/js/redirect.js
@@ -96,7 +96,8 @@
 				data : {
 					action: 'srm_validate_from_url',
 					from: fromRule.val(),
-					_wpnonce: $('#srm_redirect_nonce').val()
+					_wpnonce: $('#srm_redirect_nonce').val(),
+					current_post_id: redirectValidation.current_post_id || null
 				},
 				beforeSend : function() {
 					if ( currentRequest !== null ) {

--- a/inc/classes/class-srm-post-type.php
+++ b/inc/classes/class-srm-post-type.php
@@ -903,12 +903,21 @@ class SRM_Post_Type {
 		 */
 		$from = '/' === substr( $from, 0, 1 ) ? $from : '/' . $from;
 
+		/*
+		 * Query for an existing post.
+		 *
+		 * Two posts are queried as the post currently being edited may be returned in the results
+		 * after publication. As the `post__not_in` parameter can lead to performance issues the
+		 * current post ID is excluded via PHP rather than in the SQL argument.
+		 *
+		 * See https://docs.wpvip.com/databases/optimize-queries/using-post__not_in/
+		 */
 		$existing_post_ids = new WP_Query(
 			[
 				'meta_key'               => '_redirect_rule_from',
 				'meta_value'             => $from,
 				'fields'                 => 'ids',
-				'posts_per_page'         => 1,
+				'posts_per_page'         => 2,
 				'no_found_rows'          => true,
 				'post_type'              => 'redirect_rule',
 				'post_status'            => 'publish',
@@ -919,14 +928,22 @@ class SRM_Post_Type {
 			]
 		);
 
+		// If $_GET['current_post_id'] is set, exclude it from the post results.
+		$post_ids = $existing_post_ids->posts;
+		// Ensure the post IDs are integers before comparing.
+		$post_ids = array_map( 'absint', $post_ids );
+		if ( isset( $_GET['current_post_id'] ) ) {
+			$current_post_id = absint( $_GET['current_post_id'] );
+			$post_ids        = array_diff( $post_ids, [ $current_post_id ] );
+		}
+
 		// If no posts found, then bail out.
-		if ( empty( $existing_post_ids->posts ) ) {
+		if ( empty( $post_ids ) ) {
 			echo 1;
 			die();
 		}
 
-		$existing_post_id = $existing_post_ids->posts[0];
-
+		$existing_post_id = array_values( $post_ids )[0];
 		echo esc_url( get_edit_post_link( $existing_post_id ) );
 		die();
 	}

--- a/inc/classes/class-srm-post-type.php
+++ b/inc/classes/class-srm-post-type.php
@@ -812,7 +812,7 @@ class SRM_Post_Type {
 					'fail'            => __( 'There is an existing redirect with the same Redirect From URL. You may <a href="%s">Edit</a> the redirect or try other `from` URL.', 'safe-redirect-manager' ),
 					'ajax_url'        => admin_url( 'admin-ajax.php' ),
 					'ajax_nonce'      => wp_create_nonce( 'srm_autocomplete_nonce' ),
-					'current_post_id' => get_the_ID()
+					'current_post_id' => get_the_ID(),
 				)
 			);
 		}

--- a/inc/classes/class-srm-post-type.php
+++ b/inc/classes/class-srm-post-type.php
@@ -808,10 +808,11 @@ class SRM_Post_Type {
 				'redirectjs',
 				'redirectValidation',
 				array(
-					'urlError'   => __( 'There are some issues validating the URL. Please try again.', 'safe-redirect-manager' ),
-					'fail'       => __( 'There is an existing redirect with the same Redirect From URL. You may <a href="%s">Edit</a> the redirect or try other `from` URL.', 'safe-redirect-manager' ),
-					'ajax_url'   => admin_url( 'admin-ajax.php' ),
-					'ajax_nonce' => wp_create_nonce( 'srm_autocomplete_nonce' ),
+					'urlError'        => __( 'There are some issues validating the URL. Please try again.', 'safe-redirect-manager' ),
+					'fail'            => __( 'There is an existing redirect with the same Redirect From URL. You may <a href="%s">Edit</a> the redirect or try other `from` URL.', 'safe-redirect-manager' ),
+					'ajax_url'        => admin_url( 'admin-ajax.php' ),
+					'ajax_nonce'      => wp_create_nonce( 'srm_autocomplete_nonce' ),
+					'current_post_id' => get_the_ID()
 				)
 			);
 		}

--- a/tests/cypress/integration/safe-redirect-manager.test.js
+++ b/tests/cypress/integration/safe-redirect-manager.test.js
@@ -136,6 +136,24 @@ describe('Test redirect rules', () => {
 		cy.get('.notice-error').should('contain', 'There is an existing redirect with the same Redirect From URL.');
 	});
 
+	it('Posts are not flagged as their own duplicate', () => {
+		cy.createRedirectRule(
+			'/duplicates-not-flagged-own-duplicate-test/',
+			'/hello-world/',
+			'Rule for testing duplicate detection does not flag the current post.'
+		);
+
+		cy.visit('/wp-admin/edit.php?post_type=redirect_rule');
+		cy.get('#the-list td.title a').contains('/duplicates-not-flagged-own-duplicate-test/').click();
+
+		cy.intercept('GET', '/wp-admin/admin-ajax.php?action=srm_validate_from_url&**').as('validate')
+
+		cy.get('#srm_redirect_rule_from').click().clear().type('duplicates-not-flagged-own-duplicate-test/');
+		cy.get('#srm_redirect_rule_to').click();
+		cy.wait('@validate').its('response.statusCode').should('equal', 200);
+		cy.get('.notice-error').should('not.be.visible');
+	});
+
 	it('Can die with a 403 header', () => {
 		cy.createRedirectRule(
 			'/403-test',


### PR DESCRIPTION
### Description of the Change

Modifies the redirect duplicate manager code to include the post being edited in the ajax request. This post ID is then excluded from any results.

Adds an E2E test to ensure the same. I pushed the E2E test first, the failing test run can be seen in this [GitHub actions log](https://github.com/10up/safe-redirect-manager/actions/runs/21810555611/job/62921623296?pr=438).

Closes #437

### How to test the Change

1. Create a redirect with the redirect from URL `/testing/one/two/three`
2. Fill in the redirect to URL with whatever takes your fancy
3. Save and publish the redirect
4. Return to the redirect post list table to ensure your redirect has saved
5. Edit the redirect
6. Removing the leading slash in the redirect from URL `testing/one/two/three`
7. Tab out of the field and wait a moment
8. Ensure the warning that the redirect already exists is not displayed
9. Ensure the update button is enabled

### Changelog Entry
> Fixed - Prevent duplicate redirect detection from flagging own post as a duplicate.

### Credits
Props @peterwilsoncc 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
