### PR TITLE
Follow WordPress Coding Standards

### DIFF
--- a/assets/js/redirect.js
+++ b/assets/js/redirect.js
@@ -41,13 +41,12 @@
 			}
 		})
 		.autocomplete("instance")._renderItem = function (ul, item) {
-			return $(`<li class="srm-autocomplete__item">`)
-				.append(`
-					<div class="srm-autocomplete__item-title">${item.post_title}</div>
-					<div class="srm-autocomplete__item-url">${item.relative_url}</div>
-					<div class="srm-autocomplete__item-type">${item.post_type}</div>
-				`)
-				.appendTo(ul);
+			var $rendered = $( '<li class="srm-autocomplete__item"><div class="srm-autocomplete__item-title"></div><div class="srm-autocomplete__item-url"></div><div class="srm-autocomplete__item-type"></div></li>' );
+			$rendered.find('.srm-autocomplete__item-title').text(item.post_title);
+			$rendered.find('.srm-autocomplete__item-url').text(item.relative_url);
+			$rendered.find('.srm-autocomplete__item-type').text(item.post_type);
+
+			return $rendered.appendTo(ul);
 		};
 
 		// Disable the 'Redirect To:' field if a 4xx status code is set.

--- a/composer.json
+++ b/composer.json
@@ -9,10 +9,11 @@
     }
   ],
   "require-dev": {
-    "10up/phpcs-composer": "dev-master",
     "phpunit/phpunit": "^8.5|^9.6",
     "wp-phpunit/wp-phpunit": "^6.9",
-    "yoast/phpunit-polyfills": "^4.0"
+    "yoast/phpunit-polyfills": "^4.0",
+    "wp-coding-standards/wpcs": "^3.0",
+    "automattic/vipwpcs": "^3.0"
   },
   "scripts": {
     "lint": [

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     "wp-phpunit/wp-phpunit": "^6.9",
     "yoast/phpunit-polyfills": "^4.0",
     "wp-coding-standards/wpcs": "^3.0",
-    "automattic/vipwpcs": "^3.0"
+    "automattic/vipwpcs": "^3.0",
+    "phpcompatibility/phpcompatibility-wp": "^3.0@dev"
   },
   "scripts": {
     "lint": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,30 +4,38 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bdba3f5345daa322b27572fb96d97cc8",
+    "content-hash": "f651940b07ceba39ebd9464d5a799090",
     "packages": [],
     "packages-dev": [
         {
-            "name": "10up/phpcs-composer",
-            "version": "dev-master",
+            "name": "automattic/vipwpcs",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/10up/phpcs-composer.git",
-                "reference": "2f5c3608bc03fe1ca65acf462dd7b5008f6829a0"
+                "url": "https://github.com/Automattic/VIP-Coding-Standards.git",
+                "reference": "2b1d206d81b74ed999023cffd924f862ff2753c8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/10up/phpcs-composer/zipball/2f5c3608bc03fe1ca65acf462dd7b5008f6829a0",
-                "reference": "2f5c3608bc03fe1ca65acf462dd7b5008f6829a0",
+                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/2b1d206d81b74ed999023cffd924f862ff2753c8",
+                "reference": "2b1d206d81b74ed999023cffd924f862ff2753c8",
                 "shasum": ""
             },
             "require": {
-                "dealerdirect/phpcodesniffer-composer-installer": "*",
-                "phpcompatibility/phpcompatibility-wp": "^2",
-                "squizlabs/php_codesniffer": "^3.4.0",
-                "wp-coding-standards/wpcs": "*"
+                "php": ">=5.4",
+                "phpcsstandards/phpcsextra": "^1.2.1",
+                "phpcsstandards/phpcsutils": "^1.0.11",
+                "sirbrillig/phpcs-variable-analysis": "^2.11.18",
+                "squizlabs/php_codesniffer": "^3.9.2",
+                "wp-coding-standards/wpcs": "^3.1.0"
             },
-            "default-branch": true,
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcompatibility/php-compatibility": "^9",
+                "phpcsstandards/phpcsdevtools": "^1.0",
+                "phpunit/phpunit": "^4 || ^5 || ^6 || ^7 || ^8 || ^9"
+            },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -35,51 +43,58 @@
             ],
             "authors": [
                 {
-                    "name": "Ephraim Gregor",
-                    "email": "ephraim.gregor@10up.com"
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Automattic/VIP-Coding-Standards/graphs/contributors"
                 }
             ],
+            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress VIP minimum coding conventions",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis",
+                "wordpress"
+            ],
             "support": {
-                "issues": "https://github.com/10up/phpcs-composer/issues",
-                "source": "https://github.com/10up/phpcs-composer/tree/master"
+                "issues": "https://github.com/Automattic/VIP-Coding-Standards/issues",
+                "source": "https://github.com/Automattic/VIP-Coding-Standards",
+                "wiki": "https://github.com/Automattic/VIP-Coding-Standards/wiki"
             },
-            "time": "2021-01-08T03:03:06+00:00"
+            "time": "2024-05-10T20:31:09+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "dev-master",
+            "version": "v1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/composer-installer.git",
-                "reference": "56d537d935e72713de391b4b5511ae098a491b92"
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/56d537d935e72713de391b4b5511ae098a491b92",
-                "reference": "56d537d935e72713de391b4b5511ae098a491b92",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0 || ^2.0",
+                "composer-plugin-api": "^2.2",
                 "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
+                "squizlabs/php_codesniffer": "^3.1.0 || ^4.0"
             },
             "require-dev": {
-                "composer/composer": "*",
+                "composer/composer": "^2.2",
                 "ext-json": "*",
                 "ext-zip": "*",
-                "php-parallel-lint/php-parallel-lint": "^1.3.1",
-                "phpcompatibility/php-compatibility": "^9.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcompatibility/php-compatibility": "^9.0 || ^10.0.0@dev",
                 "yoast/phpunit-polyfills": "^1.0"
             },
-            "default-branch": true,
             "type": "composer-plugin",
             "extra": {
-                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+                "class": "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
             },
             "autoload": {
                 "psr-4": {
-                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                    "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -89,9 +104,9 @@
             "authors": [
                 {
                     "name": "Franck Nijhof",
-                    "email": "franck.nijhof@dealerdirect.com",
-                    "homepage": "http://www.frenck.nl",
-                    "role": "Developer / IT Manager"
+                    "email": "opensource@frenck.dev",
+                    "homepage": "https://frenck.dev",
+                    "role": "Open source developer"
                 },
                 {
                     "name": "Contributors",
@@ -99,7 +114,6 @@
                 }
             ],
             "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
-            "homepage": "http://www.dealerdirect.com",
             "keywords": [
                 "PHPCodeSniffer",
                 "PHP_CodeSniffer",
@@ -120,9 +134,28 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPCSStandards/composer-installer/issues",
+                "security": "https://github.com/PHPCSStandards/composer-installer/security/policy",
                 "source": "https://github.com/PHPCSStandards/composer-installer"
             },
-            "time": "2022-03-05T14:34:39+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2026-05-06T08:26:05+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -434,44 +467,44 @@
             "time": "2022-02-21T01:04:05+00:00"
         },
         {
-            "name": "phpcompatibility/php-compatibility",
-            "version": "9.3.5",
+            "name": "phpcsstandards/phpcsextra",
+            "version": "dev-develop",
             "source": {
                 "type": "git",
-                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
-                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243"
+                "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
+                "reference": "7490cf849d1d68b75705e8eb000e3e89b2eea526"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9fb324479acf6f39452e0655d2429cc0d3914243",
-                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/7490cf849d1d68b75705e8eb000e3e89b2eea526",
+                "reference": "7490cf849d1d68b75705e8eb000e3e89b2eea526",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3",
-                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
-            },
-            "conflict": {
-                "squizlabs/php_codesniffer": "2.6.2"
+                "php": ">=5.4",
+                "phpcsstandards/phpcsutils": "^1.2.0",
+                "squizlabs/php_codesniffer": "^3.13.5 || ^4.0.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcsstandards/phpcsdevcs": "^1.2.0",
+                "phpcsstandards/phpcsdevtools": "^1.2.1",
+                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
             },
-            "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
-                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
-            },
+            "default-branch": true,
             "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "LGPL-3.0-or-later"
             ],
             "authors": [
-                {
-                    "name": "Wim Godden",
-                    "homepage": "https://github.com/wimg",
-                    "role": "lead"
-                },
                 {
                     "name": "Juliette Reinders Folmer",
                     "homepage": "https://github.com/jrfnl",
@@ -479,131 +512,136 @@
                 },
                 {
                     "name": "Contributors",
-                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSExtra/graphs/contributors"
                 }
             ],
-            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
-            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "description": "A collection of sniffs and standards for use with PHP_CodeSniffer.",
             "keywords": [
-                "compatibility",
-                "phpcs",
-                "standards"
-            ],
-            "support": {
-                "issues": "https://github.com/PHPCompatibility/PHPCompatibility/issues",
-                "source": "https://github.com/PHPCompatibility/PHPCompatibility"
-            },
-            "time": "2019-12-27T09:44:58+00:00"
-        },
-        {
-            "name": "phpcompatibility/phpcompatibility-paragonie",
-            "version": "1.3.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
-                "reference": "ddabec839cc003651f2ce695c938686d1086cf43"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/ddabec839cc003651f2ce695c938686d1086cf43",
-                "reference": "ddabec839cc003651f2ce695c938686d1086cf43",
-                "shasum": ""
-            },
-            "require": {
-                "phpcompatibility/php-compatibility": "^9.0"
-            },
-            "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
-                "paragonie/random_compat": "dev-master",
-                "paragonie/sodium_compat": "dev-master"
-            },
-            "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
-                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
-            },
-            "type": "phpcodesniffer-standard",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "LGPL-3.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Wim Godden",
-                    "role": "lead"
-                },
-                {
-                    "name": "Juliette Reinders Folmer",
-                    "role": "lead"
-                }
-            ],
-            "description": "A set of rulesets for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by the Paragonie polyfill libraries.",
-            "homepage": "http://phpcompatibility.com/",
-            "keywords": [
-                "compatibility",
-                "paragonie",
-                "phpcs",
-                "polyfill",
-                "standards"
-            ],
-            "support": {
-                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/issues",
-                "source": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie"
-            },
-            "time": "2021-02-15T10:24:51+00:00"
-        },
-        {
-            "name": "phpcompatibility/phpcompatibility-wp",
-            "version": "2.1.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
-                "reference": "d55de55f88697b9cdb94bccf04f14eb3b11cf308"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/d55de55f88697b9cdb94bccf04f14eb3b11cf308",
-                "reference": "d55de55f88697b9cdb94bccf04f14eb3b11cf308",
-                "shasum": ""
-            },
-            "require": {
-                "phpcompatibility/php-compatibility": "^9.0",
-                "phpcompatibility/phpcompatibility-paragonie": "^1.0"
-            },
-            "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7"
-            },
-            "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
-                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
-            },
-            "type": "phpcodesniffer-standard",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "LGPL-3.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Wim Godden",
-                    "role": "lead"
-                },
-                {
-                    "name": "Juliette Reinders Folmer",
-                    "role": "lead"
-                }
-            ],
-            "description": "A ruleset for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by WordPress.",
-            "homepage": "http://phpcompatibility.com/",
-            "keywords": [
-                "compatibility",
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
                 "phpcs",
                 "standards",
-                "wordpress"
+                "static analysis"
             ],
             "support": {
-                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
-                "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
+                "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSExtra/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSExtra"
             },
-            "time": "2021-12-30T16:37:40+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2026-04-06T00:54:57+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsutils",
+            "version": "dev-develop",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
+                "reference": "0faa84f665c15116bc27ad6afe56e79b2f432f8f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/0faa84f665c15116bc27ad6afe56e79b2f432f8f",
+                "reference": "0faa84f665c15116bc27ad6afe56e79b2f432f8f",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.13.5 || ^4.0.1"
+            },
+            "require-dev": {
+                "ext-filter": "*",
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcsstandards/phpcsdevcs": "^1.2.0",
+                "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0 || ^3.0.0"
+            },
+            "default-branch": true,
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHPCSUtils/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSUtils/graphs/contributors"
+                }
+            ],
+            "description": "A suite of utility functions for use with PHP_CodeSniffer",
+            "homepage": "https://phpcsutils.com/",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "phpcs3",
+                "phpcs4",
+                "standards",
+                "static analysis",
+                "tokens",
+                "utility"
+            ],
+            "support": {
+                "docs": "https://phpcsutils.com/",
+                "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSUtils/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSUtils"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2026-04-21T22:07:17+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2060,17 +2098,73 @@
             "time": "2020-09-28T06:39:44+00:00"
         },
         {
-            "name": "squizlabs/php_codesniffer",
-            "version": "dev-master",
+            "name": "sirbrillig/phpcs-variable-analysis",
+            "version": "2.x-dev",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "2596a15760a1e652d64707d5ca21af0a31e5d2d8"
+                "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
+                "reference": "bcdfa62fc1c4764a7af0bc7723af9f5cc70447b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/2596a15760a1e652d64707d5ca21af0a31e5d2d8",
-                "reference": "2596a15760a1e652d64707d5ca21af0a31e5d2d8",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/bcdfa62fc1c4764a7af0bc7723af9f5cc70447b0",
+                "reference": "bcdfa62fc1c4764a7af0bc7723af9f5cc70447b0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "squizlabs/php_codesniffer": "^3.5.7 || ^4.0.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || ^1.0",
+                "phpstan/phpstan": "^1.7 || ^2.0",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.5 || ^7.0 || ^8.0 || ^9.0 || ^10.5.32 || ^11.3.3",
+                "vimeo/psalm": "^0.2 || ^0.3 || ^1.1 || ^4.24 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "VariableAnalysis\\": "VariableAnalysis/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sam Graham",
+                    "email": "php-codesniffer-variableanalysis@illusori.co.uk"
+                },
+                {
+                    "name": "Payton Swick",
+                    "email": "payton@foolord.com"
+                }
+            ],
+            "description": "A PHPCS sniff to detect problems with variables.",
+            "keywords": [
+                "phpcs",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/sirbrillig/phpcs-variable-analysis/issues",
+                "source": "https://github.com/sirbrillig/phpcs-variable-analysis",
+                "wiki": "https://github.com/sirbrillig/phpcs-variable-analysis/wiki"
+            },
+            "time": "2026-03-20T22:22:31+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "fc6c9f7bf8fc4a45498896782cd1ef32c5924f3d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/fc6c9f7bf8fc4a45498896782cd1ef32c5924f3d",
+                "reference": "fc6c9f7bf8fc4a45498896782cd1ef32c5924f3d",
                 "shasum": ""
             },
             "require": {
@@ -2080,19 +2174,13 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
             },
-            "default-branch": true,
             "bin": [
-                "bin/phpcs",
-                "bin/phpcbf"
+                "bin/phpcbf",
+                "bin/phpcs"
             ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.x-dev"
-                }
-            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
@@ -2100,21 +2188,49 @@
             "authors": [
                 {
                     "name": "Greg Sherwood",
-                    "role": "lead"
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
-                "standards"
+                "standards",
+                "static analysis"
             ],
             "support": {
-                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
-                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
-                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
             },
-            "time": "2022-03-31T22:21:18+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2026-04-21T22:11:30+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -2168,30 +2284,38 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "2.3.0",
+            "version": "3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
+                "reference": "7795ec6fa05663d716a549d0b44e47ffc8b0d4a6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
-                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7795ec6fa05663d716a549d0b44e47ffc8b0d4a6",
+                "reference": "7795ec6fa05663d716a549d0b44e47ffc8b0d4a6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.3.1"
+                "ext-filter": "*",
+                "ext-libxml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlreader": "*",
+                "php": ">=7.2",
+                "phpcsstandards/phpcsextra": "^1.5.0",
+                "phpcsstandards/phpcsutils": "^1.1.0",
+                "squizlabs/php_codesniffer": "^3.13.4"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
-                "phpcompatibility/php-compatibility": "^9.0",
-                "phpcsstandards/phpcsdevtools": "^1.0",
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcompatibility/php-compatibility": "^10.0.0@dev",
+                "phpcsstandards/phpcsdevtools": "^1.2.0",
+                "phpunit/phpunit": "^8.0 || ^9.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+                "ext-iconv": "For improved results",
+                "ext-mbstring": "For improved results"
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -2208,6 +2332,7 @@
             "keywords": [
                 "phpcs",
                 "standards",
+                "static analysis",
                 "wordpress"
             ],
             "support": {
@@ -2215,7 +2340,13 @@
                 "source": "https://github.com/WordPress/WordPress-Coding-Standards",
                 "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
             },
-            "time": "2020-05-13T23:57:56+00:00"
+            "funding": [
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "custom"
+                }
+            ],
+            "time": "2025-11-25T12:08:04+00:00"
         },
         {
             "name": "wp-phpunit/wp-phpunit",
@@ -2331,9 +2462,7 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {
-        "10up/phpcs-composer": 20
-    },
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f651940b07ceba39ebd9464d5a799090",
+    "content-hash": "4c0cc0a4d622588a38bffc9d899e8f09",
     "packages": [],
     "packages-dev": [
         {
@@ -465,6 +465,234 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpcompatibility/php-compatibility",
+            "version": "10.0.0-alpha2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "e0f0e5a3dc819a4a0f8d679a0f2453d941976e18"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/e0f0e5a3dc819a4a0f8d679a0f2453d941976e18",
+                "reference": "e0f0e5a3dc819a4a0f8d679a0f2453d941976e18",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpcsstandards/phpcsutils": "^1.1.2",
+                "squizlabs/php_codesniffer": "^3.13.3 || ^4.0"
+            },
+            "replace": {
+                "wimg/php-compatibility": "*"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcsstandards/phpcsdevcs": "^1.2.0",
+                "phpcsstandards/phpcsdevtools": "^1.2.3",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4 || ^10.5.32 || ^11.3.3",
+                "yoast/phpunit-polyfills": "^1.1.5 || ^2.0.5 || ^3.1.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.x-dev",
+                    "dev-develop": "10.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "homepage": "https://github.com/wimg",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
+            "homepage": "https://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibility/issues",
+                "security": "https://github.com/PHPCompatibility/PHPCompatibility/security/policy",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibility"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCompatibility",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcompatibility",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-11-28T11:36:33+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-paragonie",
+            "version": "2.0.0-alpha2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
+                "reference": "7a979711c87d8202b52f56c56bd719d09d8ed7f5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/7a979711c87d8202b52f56c56bd719d09d8ed7f5",
+                "reference": "7a979711c87d8202b52f56c56bd719d09d8ed7f5",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^10.0@dev"
+            },
+            "require-dev": {
+                "paragonie/random_compat": "dev-master",
+                "paragonie/sodium_compat": "dev-master"
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A set of rulesets for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by the Paragonie polyfill libraries.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "paragonie",
+                "phpcs",
+                "polyfill",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/issues",
+                "security": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/security/policy",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCompatibility",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcompatibility",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-11-29T13:09:49+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-wp",
+            "version": "3.0.0-alpha2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
+                "reference": "bd53f24e7528422ac51d64dc8d53e8d4c4a877b3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/bd53f24e7528422ac51d64dc8d53e8d4c4a877b3",
+                "reference": "bd53f24e7528422ac51d64dc8d53e8d4c4a877b3",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^10.0@dev",
+                "phpcompatibility/phpcompatibility-paragonie": "^2.0@dev"
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A ruleset for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by WordPress.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
+                "security": "https://github.com/PHPCompatibility/PHPCompatibilityWP/security/policy",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCompatibility",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcompatibility",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-12-16T13:35:20+00:00"
         },
         {
             "name": "phpcsstandards/phpcsextra",
@@ -2462,7 +2690,9 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {},
+    "stability-flags": {
+        "phpcompatibility/phpcompatibility-wp": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {},

--- a/inc/classes/class-srm-loop-detection.php
+++ b/inc/classes/class-srm-loop-detection.php
@@ -133,7 +133,7 @@ class SRM_Loop_Detection {
 	 */
 	public static function get_cycle_source( $cycle_source = array() ) {
 		return array_map(
-			function( $source ) {
+			function ( $source ) {
 				return array(
 					'path' => wp_parse_url( esc_url( $source['destination'] ), PHP_URL_PATH ),
 					'id'   => $source['id'],

--- a/inc/classes/class-srm-loop-detection.php
+++ b/inc/classes/class-srm-loop-detection.php
@@ -30,13 +30,8 @@ class SRM_Loop_Detection {
 			$source_url      = '';
 			$destination_url = '';
 
-			if ( function_exists( 'wp_parse_url' ) ) {
-				$current_url  = wp_parse_url( home_url() );
-				$redirect_url = wp_parse_url( $destination );
-			} else {
-				$current_url  = parse_url( home_url() ); // phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url
-				$redirect_url = parse_url( $destination ); // phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url
-			}
+			$current_url  = wp_parse_url( home_url() );
+			$redirect_url = wp_parse_url( $destination );
 
 			$this_host     = ( is_array( $current_url ) && ! empty( $current_url['host'] ) ) ? $current_url['host'] : '';
 			$redirect_host = ( is_array( $redirect_url ) && ! empty( $redirect_url['host'] ) ) ? $redirect_url['host'] : '';

--- a/inc/classes/class-srm-post-type.php
+++ b/inc/classes/class-srm-post-type.php
@@ -346,11 +346,13 @@ class SRM_Post_Type {
 			2  => esc_html__( 'Custom field updated.', 'safe-redirect-manager' ),
 			3  => esc_html__( 'Custom field deleted.', 'safe-redirect-manager' ),
 			4  => $message_tpl( __( 'updated', 'safe-redirect-manager' ) ),
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Not required for message handler.
 			5  => isset( $_GET['revision'] )
 				? $message_tpl(
 					sprintf(
 						/* translators: %s: the revision title */
 						esc_html__( 'restored to revision from %s', 'safe-redirect-manager' ),
+						// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Not required for message handler.
 						wp_post_revision_title( (int) $_GET['revision'], false )
 					)
 				)

--- a/inc/classes/class-srm-post-type.php
+++ b/inc/classes/class-srm-post-type.php
@@ -834,6 +834,7 @@ class SRM_Post_Type {
 				'redirectValidation',
 				array(
 					'urlError'        => __( 'There are some issues validating the URL. Please try again.', 'safe-redirect-manager' ),
+					// translators: %s is the URL to the edit screen of the existing redirect rule with the same "Redirect From" value.
 					'fail'            => __( 'There is an existing redirect with the same Redirect From URL. You may <a href="%s">Edit</a> the redirect or try other `from` URL.', 'safe-redirect-manager' ),
 					'ajax_url'        => admin_url( 'admin-ajax.php' ),
 					'ajax_nonce'      => wp_create_nonce( 'srm_autocomplete_nonce' ),

--- a/inc/classes/class-srm-post-type.php
+++ b/inc/classes/class-srm-post-type.php
@@ -364,7 +364,7 @@ class SRM_Post_Type {
 				sprintf(
 					/* translators: %s: publish box date format, see http://php.net/date */
 					esc_html__( 'scheduled for %s', 'safe-redirect-manager' ),
-					date_i18n( esc_html__( 'M j, Y @ G:i' ), strtotime( $post->post_date ) )
+					date_i18n( esc_html__( 'M j, Y @ G:i', 'safe-redirect-manager' ), strtotime( $post->post_date ) )
 				)
 			),
 			10 => $message_tpl( esc_html__( 'draft updated', 'safe-redirect-manager' ) ),

--- a/inc/classes/class-srm-post-type.php
+++ b/inc/classes/class-srm-post-type.php
@@ -123,9 +123,14 @@ class SRM_Post_Type {
 	 */
 	public function disable_core_search( $query ) {
 		if ( $query->is_search() && 'redirect_rule' === $query->get( 'post_type' ) ) {
-			// Store a reference to the search term for later use.
+			/*
+			 * Store a reference to the search term for later use, then
+			 * remove the core search term so SRM can provide the custom
+			 * search capability rather than having core build its search.
+			 */
+			// phpcs:ignore WordPressVIPMinimum.Hooks.PreGetPosts.PreGetPosts -- Modifying search intentionally.
 			$this->redirect_search_term = $query->get( 's' );
-			// Don't let core build it's search clauses since we override them.
+			// phpcs:ignore WordPressVIPMinimum.Hooks.PreGetPosts.PreGetPosts -- Modifying search intentionally.
 			$query->set( 's', '' );
 		}
 	}

--- a/inc/classes/class-srm-post-type.php
+++ b/inc/classes/class-srm-post-type.php
@@ -525,13 +525,13 @@ class SRM_Post_Type {
 			}
 
 			if ( ! empty( $_POST['srm_redirect_rule_from'] ) ) {
-				update_post_meta( $post_id, '_redirect_rule_from', srm_sanitize_redirect_from( $_POST['srm_redirect_rule_from'], $allow_regex ) );
+				update_post_meta( $post_id, '_redirect_rule_from', srm_sanitize_redirect_from( wp_unslash( $_POST['srm_redirect_rule_from'] ), $allow_regex ) );
 			} else {
 				delete_post_meta( $post_id, '_redirect_rule_from' );
 			}
 
 			if ( ! empty( $_POST['srm_redirect_rule_to'] ) ) {
-				update_post_meta( $post_id, '_redirect_rule_to', srm_sanitize_redirect_to( $_POST['srm_redirect_rule_to'] ) );
+				update_post_meta( $post_id, '_redirect_rule_to', srm_sanitize_redirect_to( wp_unslash( $_POST['srm_redirect_rule_to'] ) ) );
 			} else {
 				delete_post_meta( $post_id, '_redirect_rule_to' );
 			}
@@ -549,13 +549,13 @@ class SRM_Post_Type {
 			}
 
 			if ( ! empty( $_POST['srm_redirect_rule_message'] ) ) {
-				update_post_meta( $post_id, '_redirect_rule_message', sanitize_text_field( $_POST['srm_redirect_rule_message'] ) );
+				update_post_meta( $post_id, '_redirect_rule_message', sanitize_text_field( wp_unslash( $_POST['srm_redirect_rule_message'] ) ) );
 			} else {
 				delete_post_meta( $post_id, '_redirect_rule_message' );
 			}
 
 			if ( ! empty( $_POST['srm_redirect_rule_notes'] ) ) {
-				update_post_meta( $post_id, '_redirect_rule_notes', sanitize_text_field( $_POST['srm_redirect_rule_notes'] ) );
+				update_post_meta( $post_id, '_redirect_rule_notes', sanitize_text_field( wp_unslash( $_POST['srm_redirect_rule_notes'] ) ) );
 			} else {
 				delete_post_meta( $post_id, '_redirect_rule_notes' );
 			}
@@ -569,7 +569,7 @@ class SRM_Post_Type {
 		}
 
 		if ( ! empty( $_REQUEST['srm_redirect_ajax_nonce'] )
-			&& wp_verify_nonce( $_REQUEST['srm_redirect_ajax_nonce'], 'srm-save-redirect-ajax-meta' )
+			&& wp_verify_nonce( sanitize_key( wp_unslash( $_REQUEST['srm_redirect_ajax_nonce'] ) ), 'srm-save-redirect-ajax-meta' )
 			&& current_user_can( 'edit_post', $post_id )
 		) {
 			if ( ! empty( $_REQUEST['srm_redirect_rule_status_code'] ) && '-1' !== $_REQUEST['srm_redirect_rule_status_code'] ) {

--- a/inc/classes/class-srm-post-type.php
+++ b/inc/classes/class-srm-post-type.php
@@ -514,7 +514,7 @@ class SRM_Post_Type {
 		}
 
 		// Update post meta for redirect rules
-		if ( ! empty( $_POST['srm_redirect_nonce'] ) && wp_verify_nonce( $_POST['srm_redirect_nonce'], 'srm-save-redirect-meta' ) && current_user_can( 'edit_post', $post_id ) ) {
+		if ( ! empty( $_POST['srm_redirect_nonce'] ) && wp_verify_nonce( sanitize_key( wp_unslash( $_POST['srm_redirect_nonce'] ) ), 'srm-save-redirect-meta' ) && current_user_can( 'edit_post', $post_id ) ) {
 
 			if ( ! empty( $_POST['srm_redirect_rule_from_regex'] ) ) {
 				$allow_regex = (bool) $_POST['srm_redirect_rule_from_regex'];

--- a/inc/classes/class-srm-post-type.php
+++ b/inc/classes/class-srm-post-type.php
@@ -331,43 +331,81 @@ class SRM_Post_Type {
 	public function filter_redirect_updated_messages( $messages ) {
 		global $post;
 
-		$message_tpl = function ( $message ) {
-			return sprintf(
-				/* translators: %1%s: message status, %2%s: URL to the list of redirect rules */
-				__( 'Redirect rule %1$s. <a href="%2$s">&larr; Back to rules</a>', 'safe-redirect-manager' ),
-				$message,
-				esc_url( admin_url( 'edit.php?post_type=redirect_rule' ) )
-			);
-		};
+		$scheduled_date = sprintf(
+			/* translators: Publish box date string. 1: Date, 2: Time. */
+			__( '%1$s at %2$s', 'safe-redirect-manager' ),
+			/* translators: Publish box date format, see https://www.php.net/manual/datetime.format.php */
+			date_i18n( _x( 'M j, Y', 'publish box date format', 'safe-redirect-manager' ), strtotime( $post->post_date ) ),
+			/* translators: Publish box time format, see https://www.php.net/manual/datetime.format.php */
+			date_i18n( _x( 'H:i', 'publish box time format', 'safe-redirect-manager' ), strtotime( $post->post_date ) )
+		);
 
 		$messages['redirect_rule'] = array(
 			0  => '', // Unused. Messages start at index 1.
-			1  => $message_tpl( esc_html__( 'updated', 'safe-redirect-manager' ) ),
-			2  => esc_html__( 'Custom field updated.', 'safe-redirect-manager' ),
-			3  => esc_html__( 'Custom field deleted.', 'safe-redirect-manager' ),
-			4  => $message_tpl( __( 'updated', 'safe-redirect-manager' ) ),
+			1  => wp_kses_post(
+				sprintf(
+					// translators: %1$s URL to the list of redirect rules.
+					__( 'Redirect rule updated. <a href="%1$s">&larr; Back to rules</a>', 'safe-redirect-manager' ),
+					esc_url( admin_url( 'edit.php?post_type=redirect_rule' ) )
+				)
+			),
+			2  => __( 'Custom field updated.', 'safe-redirect-manager' ),
+			3  => __( 'Custom field deleted.', 'safe-redirect-manager' ),
+			4  => wp_kses_post(
+				sprintf(
+					// translators: %1$s URL to the list of redirect rules.
+					__( 'Redirect rule updated. <a href="%1$s">&larr; Back to rules</a>', 'safe-redirect-manager' ),
+					esc_url( admin_url( 'edit.php?post_type=redirect_rule' ) )
+				)
+			),
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Not required for message handler.
 			5  => isset( $_GET['revision'] )
-				? $message_tpl(
+				? wp_kses_post(
 					sprintf(
-						/* translators: %s: the revision title */
-						esc_html__( 'restored to revision from %s', 'safe-redirect-manager' ),
+						// translators: %1$s: the revision title, %2$s: URL to the list of redirect rules.
+						__( 'Redirect rule restored to revision from %1$s. <a href="%2$s">&larr; Back to rules</a>', 'safe-redirect-manager' ),
 						// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Not required for message handler.
-						wp_post_revision_title( (int) $_GET['revision'], false )
+						wp_post_revision_title( (int) $_GET['revision'], false ),
+						esc_url( admin_url( 'edit.php?post_type=redirect_rule' ) )
 					)
 				)
 				: false,
-			6  => $message_tpl( esc_html__( 'published', 'safe-redirect-manager' ) ),
-			7  => $message_tpl( esc_html__( 'saved', 'safe-redirect-manager' ) ),
-			8  => $message_tpl( esc_html__( 'submitted', 'safe-redirect-manager' ) ),
-			9  => $message_tpl(
+			6  => wp_kses_post(
 				sprintf(
-					/* translators: %s: publish box date format, see http://php.net/date */
-					esc_html__( 'scheduled for %s', 'safe-redirect-manager' ),
-					date_i18n( esc_html__( 'M j, Y @ G:i', 'safe-redirect-manager' ), strtotime( $post->post_date ) )
+					// translators: %1$s URL to the list of redirect rules.
+					__( 'Redirect rule published. <a href="%1$s">&larr; Back to rules</a>', 'safe-redirect-manager' ),
+					esc_url( admin_url( 'edit.php?post_type=redirect_rule' ) )
 				)
 			),
-			10 => $message_tpl( esc_html__( 'draft updated', 'safe-redirect-manager' ) ),
+			7  => wp_kses_post(
+				sprintf(
+					// translators: %1$s URL to the list of redirect rules.
+					__( 'Redirect rule saved. <a href="%1$s">&larr; Back to rules</a>', 'safe-redirect-manager' ),
+					esc_url( admin_url( 'edit.php?post_type=redirect_rule' ) )
+				)
+			),
+			8  => wp_kses_post(
+				sprintf(
+					// translators: %1$s URL to the list of redirect rules.
+					__( 'Redirect rule submitted. <a href="%1$s">&larr; Back to rules</a>', 'safe-redirect-manager' ),
+					esc_url( admin_url( 'edit.php?post_type=redirect_rule' ) )
+				)
+			),
+			9  => wp_kses_post(
+				sprintf(
+					// translators: %1$s: the scheduled date, %2$s: URL to the list of redirect rules.
+					__( 'Redirect rule scheduled for: %1$s. <a href="%2$s">&larr; Back to rules</a>', 'safe-redirect-manager' ),
+					'<strong>' . $scheduled_date . '</strong>',
+					esc_url( admin_url( 'edit.php?post_type=redirect_rule' ) )
+				)
+			),
+			10 => wp_kses_post(
+				sprintf(
+					// translators: %1$s URL to the list of redirect rules.
+					__( 'Redirect rule draft updated. <a href="%1$s">&larr; Back to rules</a>', 'safe-redirect-manager' ),
+					esc_url( admin_url( 'edit.php?post_type=redirect_rule' ) )
+				)
+			),
 		);
 
 		return $messages;

--- a/inc/classes/class-srm-post-type.php
+++ b/inc/classes/class-srm-post-type.php
@@ -90,6 +90,7 @@ class SRM_Post_Type {
 	 * @return array
 	 */
 	public function filter_hidden_columns( $hidden ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Post List Table.
 		if ( empty( $_GET['post_type'] ) || 'redirect_rule' !== $_GET['post_type'] ) {
 			return $hidden;
 		}

--- a/inc/classes/class-srm-post-type.php
+++ b/inc/classes/class-srm-post-type.php
@@ -827,8 +827,8 @@ class SRM_Post_Type {
 		if ( 'redirect_rule' === get_post_type() ) {
 			wp_enqueue_style( 'redirectjs', SRM_PLUGIN_URL . 'assets/css/redirect.css', array(), SRM_VERSION );
 			wp_enqueue_script( 'bulk-select', SRM_PLUGIN_URL . 'assets/js/bulk-select.js', array( 'jquery' ), SRM_VERSION, true );
-			wp_enqueue_script( 'redirectjs', SRM_PLUGIN_URL . 'assets/js/redirect.js', array( 'jquery' ), SRM_VERSION );
-			wp_enqueue_script( 'quick-bulk-editjs', SRM_PLUGIN_URL . 'assets/js/quick-bulk-edit.js', array( 'jquery', 'inline-edit-post' ), SRM_VERSION );
+			wp_enqueue_script( 'redirectjs', SRM_PLUGIN_URL . 'assets/js/redirect.js', array( 'jquery' ), SRM_VERSION, true );
+			wp_enqueue_script( 'quick-bulk-editjs', SRM_PLUGIN_URL . 'assets/js/quick-bulk-edit.js', array( 'jquery', 'inline-edit-post' ), SRM_VERSION, true );
 			wp_localize_script(
 				'redirectjs',
 				'redirectValidation',

--- a/inc/classes/class-srm-post-type.php
+++ b/inc/classes/class-srm-post-type.php
@@ -940,8 +940,8 @@ class SRM_Post_Type {
 		 */
 		$existing_post_ids = new WP_Query(
 			array(
-				'meta_key'               => '_redirect_rule_from',
-				'meta_value'             => $from,
+				'meta_key'               => '_redirect_rule_from', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Indexed meta key.
+				'meta_value'             => $from, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- Required for lookup.
 				'fields'                 => 'ids',
 				'posts_per_page'         => 2,
 				'no_found_rows'          => true,

--- a/inc/classes/class-srm-post-type.php
+++ b/inc/classes/class-srm-post-type.php
@@ -208,7 +208,24 @@ class SRM_Post_Type {
 	 * @return bool
 	 */
 	private function is_plugin_page() {
-		return (bool) ( get_post_type() === 'redirect_rule' || ( isset( $_GET['post_type'] ) && 'redirect_rule' === $_GET['post_type'] ) );
+		if ( ! function_exists( 'get_current_screen' ) || ! get_current_screen() ) {
+			// Not in the admin or screen not defined.
+			return false;
+		}
+
+		$current_screen = get_current_screen();
+
+		// New/Edit post screen.
+		if ( 'post' === $current_screen->base && 'redirect_rule' === $current_screen->post_type ) {
+			return true;
+		}
+
+		// List table screen.
+		if ( 'edit-redirect_rule' === $current_screen->id && 'redirect_rule' === $current_screen->post_type ) {
+			return true;
+		}
+
+		return false;
 	}
 
 	/**

--- a/inc/classes/class-srm-post-type.php
+++ b/inc/classes/class-srm-post-type.php
@@ -329,7 +329,7 @@ class SRM_Post_Type {
 	 * @return array
 	 */
 	public function filter_redirect_updated_messages( $messages ) {
-		global $post, $post_ID;
+		global $post;
 
 		$message_tpl = function ( $message ) {
 			return sprintf(

--- a/inc/classes/class-srm-post-type.php
+++ b/inc/classes/class-srm-post-type.php
@@ -892,6 +892,10 @@ class SRM_Post_Type {
 
 		$suggestions = array();
 		foreach ( $query as $post ) {
+			if ( ! is_post_publicly_viewable( $post->ID ) ) {
+				return;
+			}
+
 			$suggestions[] = array(
 				'relative_url' => wp_make_link_relative( get_the_permalink( $post->ID ) ),
 				'post_title'   => $post->post_title,

--- a/inc/classes/class-srm-post-type.php
+++ b/inc/classes/class-srm-post-type.php
@@ -308,7 +308,7 @@ class SRM_Post_Type {
 	public function filter_redirect_updated_messages( $messages ) {
 		global $post, $post_ID;
 
-		$message_tpl = function( $message ) {
+		$message_tpl = function ( $message ) {
 			return sprintf(
 				/* translators: %1%s: message status, %2%s: URL to the list of redirect rules */
 				__( 'Redirect rule %1$s. <a href="%2$s">&larr; Back to rules</a>', 'safe-redirect-manager' ),
@@ -913,7 +913,7 @@ class SRM_Post_Type {
 		 * See https://docs.wpvip.com/databases/optimize-queries/using-post__not_in/
 		 */
 		$existing_post_ids = new WP_Query(
-			[
+			array(
 				'meta_key'               => '_redirect_rule_from',
 				'meta_value'             => $from,
 				'fields'                 => 'ids',
@@ -925,7 +925,7 @@ class SRM_Post_Type {
 				'order'                  => 'ASC',
 				'update_post_meta_cache' => false,
 				'update_post_term_cache' => false,
-			]
+			)
 		);
 
 		// If $_GET['current_post_id'] is set, exclude it from the post results.
@@ -934,7 +934,7 @@ class SRM_Post_Type {
 		$post_ids = array_map( 'absint', $post_ids );
 		if ( isset( $_GET['current_post_id'] ) ) {
 			$current_post_id = absint( $_GET['current_post_id'] );
-			$post_ids        = array_diff( $post_ids, [ $current_post_id ] );
+			$post_ids        = array_diff( $post_ids, array( $current_post_id ) );
 		}
 
 		// If no posts found, then bail out.

--- a/inc/classes/class-srm-post-type.php
+++ b/inc/classes/class-srm-post-type.php
@@ -891,7 +891,7 @@ class SRM_Post_Type {
 		}
 
 		$suggestions = array();
-		foreach ( $query as $key => $post ) {
+		foreach ( $query as $post ) {
 			$suggestions[] = array(
 				'relative_url' => wp_make_link_relative( get_the_permalink( $post->ID ) ),
 				'post_title'   => $post->post_title,

--- a/inc/classes/class-srm-redirect.php
+++ b/inc/classes/class-srm-redirect.php
@@ -398,10 +398,12 @@ class SRM_Redirect {
 					$main_site_id = get_main_site_id();
 
 					if ( ! empty( $main_site_id ) ) {
+						// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.switch_to_blog_switch_to_blog -- Switch to allow DB checks.
 						switch_to_blog( $main_site_id );
 
 						$this->maybe_redirect();
 
+						// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.switch_to_blog_switch_to_blog -- Switch back to original site.
 						switch_to_blog( $blog_id );
 					}
 				}

--- a/inc/classes/class-srm-redirect.php
+++ b/inc/classes/class-srm-redirect.php
@@ -283,7 +283,7 @@ class SRM_Redirect {
 		 * @param {string} $request_path Request path. Default `$_SERVER['REQUEST_URI']`.
 		 * @returns {string} Request path.
 		 */
-		$requested_path   = esc_url_raw( apply_filters( 'srm_requested_path', sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) ?? '' ) );
+		$requested_path   = esc_url_raw( apply_filters( 'srm_requested_path', sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ) ) ) );
 		$requested_path   = untrailingslashit( stripslashes( $requested_path ) );
 		$matched_redirect = $this->match_redirect( $requested_path );
 

--- a/inc/classes/class-srm-redirect.php
+++ b/inc/classes/class-srm-redirect.php
@@ -90,15 +90,11 @@ class SRM_Redirect {
 			return false;
 		}
 
-		/**
+		/*
 		 * If WordPress resides in a directory that is not the public root, we have to chop
 		 * the pre-WP path off the requested path.
 		 */
-		if ( function_exists( 'wp_parse_url' ) ) {
-			$parsed_home_url = wp_parse_url( home_url() );
-		} else {
-			$parsed_home_url = parse_url( home_url() ); // phpcs:ignore
-		}
+		$parsed_home_url = wp_parse_url( home_url() );
 
 		if ( isset( $parsed_home_url['path'] ) && '/' !== $parsed_home_url['path'] ) {
 			$requested_path = preg_replace( '@' . $parsed_home_url['path'] . '@i', '', $requested_path, 1 );
@@ -138,11 +134,7 @@ class SRM_Redirect {
 			$normalized_requested_path = $requested_path;
 		}
 
-		if ( function_exists( 'wp_parse_url' ) ) {
-			$parsed_requested_path = wp_parse_url( $normalized_requested_path );
-		} else {
-			$parsed_requested_path = parse_url( $normalized_requested_path ); // phpcs:ignore
-		}
+		$parsed_requested_path = wp_parse_url( $normalized_requested_path );
 		// Normalize the request path with and without query strings, for comparison later
 		$normalized_requested_path_no_query = '';
 		$requested_query_params             = '';
@@ -212,14 +204,10 @@ class SRM_Redirect {
 			// If the requested path matches a redirect rule...
 			// this variable is not used after this boolean.
 			if ( $matched_path ) {
-				/**
+				/*
 				 * Whitelist redirect host
 				 */
-				if ( function_exists( 'wp_parse_url' ) ) {
-					$parsed_redirect = wp_parse_url( $redirect_to );
-				} else {
-					$parsed_redirect = parse_url( $redirect_to ); // phpcs:ignore
-				}
+				$parsed_redirect = wp_parse_url( $redirect_to );
 
 				if ( is_array( $parsed_redirect ) && ! empty( $parsed_redirect['host'] ) ) {
 					$this->whitelist_host = $parsed_redirect['host'];

--- a/inc/classes/class-srm-redirect.php
+++ b/inc/classes/class-srm-redirect.php
@@ -253,14 +253,14 @@ class SRM_Redirect {
 				$filtered_redirect_to  = apply_filters( 'srm_redirect_to', $redirect_to );
 				$sanitized_redirect_to = esc_url_raw( $filtered_redirect_to );
 
-				return [
+				return array(
 					'redirect_to'  => $sanitized_redirect_to,
 					'status_code'  => $status_code,
 					'enable_regex' => $enable_regex,
 					'redirect_id'  => $redirect_id,
 					'force_https'  => $force_https,
 					'message'      => $message,
-				];
+				);
 			}
 		}
 
@@ -437,4 +437,3 @@ class SRM_Redirect {
 		return $instance;
 	}
 }
-

--- a/inc/classes/class-srm-redirect.php
+++ b/inc/classes/class-srm-redirect.php
@@ -158,8 +158,9 @@ class SRM_Redirect {
 			$status_code  = $redirect['status_code'];
 			$enable_regex = ( isset( $redirect['enable_regex'] ) ) ? $redirect['enable_regex'] : false;
 			$redirect_id  = $redirect['ID'];
-			$force_https  = ! empty( $redirect['force_https'] ) && true == $redirect['force_https'];
-			$message      = $redirect['message'] ?? '';
+			// phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual -- truethy check.
+			$force_https = ! empty( $redirect['force_https'] ) && true == $redirect['force_https'];
+			$message     = $redirect['message'] ?? '';
 
 			// check if the redirection destination is valid, otherwise just skip it (unless this is a 4xx request)
 			if ( empty( $redirect_to ) && ! in_array( $status_code, array( 403, 404, 410 ), true ) ) {

--- a/inc/classes/class-srm-redirect.php
+++ b/inc/classes/class-srm-redirect.php
@@ -327,7 +327,7 @@ class SRM_Redirect {
 			wp_die(
 				esc_html( $matched_redirect['message'] ),
 				'',
-				$matched_redirect['status_code'] // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				(int) $matched_redirect['status_code']
 			);
 			return;
 		}

--- a/inc/classes/class-srm-wp-cli.php
+++ b/inc/classes/class-srm-wp-cli.php
@@ -5,7 +5,7 @@
  * @package safe-redirect-manager
  */
 
-use \WP_CLI\Utils;
+use WP_CLI\Utils;
 
 /**
  * WP CLI command class
@@ -37,10 +37,10 @@ class SRM_WP_CLI extends WP_CLI_Command {
 	public function cli_list( $args, $assoc_args ) {
 		$assoc_args = wp_parse_args(
 			$assoc_args,
-			[
+			array(
 				'show_total' => true,
 				'format'     => 'table',
-			]
+			)
 		);
 
 		if ( 'false' === $assoc_args['show_total'] ) {
@@ -58,7 +58,7 @@ class SRM_WP_CLI extends WP_CLI_Command {
 
 		$redirects = srm_get_redirects( array( 'post_status' => 'any' ), true );
 		$redirects = array_map(
-			function( $item ) use ( $assoc_args ) {
+			function ( $item ) use ( $assoc_args ) {
 				if ( 'table' === $assoc_args['format'] ) {
 					$item['enable_regex'] = $item['enable_regex'] ? 'true' : 'false';
 				} else {
@@ -207,10 +207,10 @@ class SRM_WP_CLI extends WP_CLI_Command {
 			$id = srm_create_redirect( $sanitized_redirect_from, $sanitized_redirect_to, $http_status );
 			if ( is_wp_error( $id ) ) {
 				WP_CLI::warning( 'Error - ' . $id->get_error_message() );
-				$skipped++;
+				++$skipped;
 			} else {
 				WP_CLI::line( "Success - Created redirect from '{$sanitized_redirect_from}' to '{$sanitized_redirect_to}'" );
-				$created++;
+				++$created;
 			}
 		}
 		WP_CLI::success( "All done! {$created} redirects were created, {$skipped} were skipped" );
@@ -313,25 +313,25 @@ class SRM_WP_CLI extends WP_CLI_Command {
 
 		$assoc_args = wp_parse_args(
 			$assoc_args,
-			[
+			array(
 				'filename' => 'srm-redirects',
-			]
+			)
 		);
 
-		$redirects = srm_get_redirects( [ 'post_status' => 'any' ], true );
+		$redirects = srm_get_redirects( array( 'post_status' => 'any' ), true );
 
 		if ( empty( $redirects ) ) {
 			WP_CLI::error( 'There are no redirects available. Please add some first and then try again.' );
 		}
 
-		$fields = [
+		$fields = array(
 			'ID',
 			'redirect_from',
 			'redirect_to',
 			'status_code',
 			'enable_regex',
 			'post_status',
-		];
+		);
 
 		$file_name = $assoc_args['filename'] . '.csv';
 

--- a/inc/classes/class-srm-wp-cli.php
+++ b/inc/classes/class-srm-wp-cli.php
@@ -155,11 +155,10 @@ class SRM_WP_CLI extends WP_CLI_Command {
 	 * Import .htaccess file redirects
 	 *
 	 * @param array $args Array of arguments
-	 * @param array $assoc_args Array of associate arguments
 	 * @subcommand import-htaccess
 	 * @synopsis <file>
 	 */
-	public function import_htaccess( $args, $assoc_args ) {
+	public function import_htaccess( $args ) {
 		list( $file ) = $args;
 
 		// phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown

--- a/inc/classes/class-srm-wp-cli.php
+++ b/inc/classes/class-srm-wp-cli.php
@@ -162,6 +162,7 @@ class SRM_WP_CLI extends WP_CLI_Command {
 	public function import_htaccess( $args, $assoc_args ) {
 		list( $file ) = $args;
 
+		// phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
 		$contents = file_get_contents( $file );
 		if ( ! $contents ) {
 			WP_CLI::error( 'Error retrieving .htaccess file' );
@@ -340,7 +341,8 @@ class SRM_WP_CLI extends WP_CLI_Command {
 			WP_CLI::confirm( 'Proceed with rewriting the existing file?' );
 		}
 
-		$file_resource = fopen( $file_name, 'w' ); //phpcs:ignore
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+		$file_resource = fopen( $file_name, 'w' );
 
 		Utils\write_csv( $file_resource, $redirects, $fields );
 

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -176,13 +176,8 @@ function srm_flush_cache() {
  * @return boolean
  */
 function srm_check_for_possible_redirect_loops() {
-	$redirects = srm_get_redirects();
-
-	if ( function_exists( 'wp_parse_url' ) ) {
-		$current_url = wp_parse_url( home_url() );
-	} else {
-		$current_url = parse_url( home_url() );
-	}
+	$redirects   = srm_get_redirects();
+	$current_url = wp_parse_url( home_url() );
 
 	$this_host = ( is_array( $current_url ) && ! empty( $current_url['host'] ) ) ? $current_url['host'] : '';
 
@@ -191,13 +186,8 @@ function srm_check_for_possible_redirect_loops() {
 
 		// check redirect from against all redirect to's
 		foreach ( $redirects as $compare_redirect ) {
-			$redirect_to = $compare_redirect['redirect_to'];
-
-			if ( function_exists( 'wp_parse_url' ) ) {
-				$redirect_url = wp_parse_url( $redirect_to );
-			} else {
-				$redirect_url = parse_url( $redirect_to );
-			}
+			$redirect_to  = $compare_redirect['redirect_to'];
+			$redirect_url = wp_parse_url( $redirect_to );
 
 			$redirect_host = ( is_array( $redirect_url ) && ! empty( $redirect_url['host'] ) ) ? $redirect_url['host'] : '';
 

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -407,6 +407,7 @@ function srm_import_file( $file, $args ) {
 
 	// open file pointer if $file is not a resource
 	if ( ! is_resource( $file ) ) {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
 		$handle = fopen( $file, 'rb' );
 		if ( ! $handle ) {
 			$doing_wp_cli && WP_CLI::error( sprintf( 'Error retrieving %s file', basename( $file ) ) );
@@ -452,6 +453,7 @@ function srm_import_file( $file, $args ) {
 
 	// close an open file pointer if we've opened it
 	if ( $close_handle ) {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
 		fclose( $handle );
 	}
 

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -249,6 +249,7 @@ function srm_create_redirect( $redirect_from, $redirect_to, $status_code = 302, 
 	}
 
 	// Check if the redirect already exists.
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Perf. Caching not required as it would be flushed below.
 	$existing_redirect = $wpdb->get_row(
 		$wpdb->prepare(
 			"SELECT

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -422,6 +422,7 @@ function srm_import_file( $file, $args ) {
 	$skipped = 0;
 	$headers = fgetcsv( $handle, null, ',', '"', '\\' );
 
+	// phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition -- Intended.
 	while ( ( $row = fgetcsv( $handle, null, ',', '"', '\\' ) ) ) {
 		// validate
 		$rule = is_array( $row ) ? array_combine( $headers, $row ) : array();

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -401,7 +401,7 @@ function srm_import_file( $file, $args ) {
 
 	// enable line endings auto detection
 	if ( version_compare( PHP_VERSION, '8.1', '<' ) ) {
-		// phpcs:ignore Generic.PHP.NoSilencedErrors.Forbidden, PHPCompatibility.IniDirectives.RemovedIniDirectives.auto_detect_line_endingsDeprecated -- required for PHP 8.0 and earlier.
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, Generic.PHP.NoSilencedErrors.Forbidden, PHPCompatibility.IniDirectives.RemovedIniDirectives.auto_detect_line_endingsDeprecated -- required for PHP 8.0 and earlier.
 		@ini_set( 'auto_detect_line_endings', true );
 	}
 

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -77,7 +77,7 @@ function srm_get_redirects( $args = array(), $hard = false ) {
 				$redirects[] = $redirect_data;
 			}
 
-			$i++;
+			++$i;
 
 		}
 
@@ -435,7 +435,7 @@ function srm_import_file( $file, $args ) {
 		$rule = is_array( $row ) ? array_combine( $headers, $row ) : array();
 		if ( empty( $rule ) || empty( $rule[ $args['source'] ] ) || empty( $rule[ $args['target'] ] ) ) {
 			$doing_wp_cli && WP_CLI::warning( 'Skipping - redirection rule is formatted improperly.' );
-			$skipped++;
+			++$skipped;
 			continue;
 		}
 
@@ -452,10 +452,10 @@ function srm_import_file( $file, $args ) {
 
 		if ( is_wp_error( $id ) ) {
 			$doing_wp_cli && WP_CLI::warning( $id );
-			$skipped++;
+			++$skipped;
 		} else {
 			$doing_wp_cli && WP_CLI::line( "Success - Created redirect from '{$redirect_from}' to '{$redirect_to}'" );
-			$created++;
+			++$created;
 		}
 	}
 

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -401,7 +401,8 @@ function srm_import_file( $file, $args ) {
 
 	// enable line endings auto detection
 	if ( version_compare( PHP_VERSION, '8.1', '<' ) ) {
-		@ini_set( 'auto_detect_line_endings', true ); // phpcs:ignore PHPCompatibility.IniDirectives.RemovedIniDirectives.auto_detect_line_endingsDeprecated
+		// phpcs:ignore Generic.PHP.NoSilencedErrors.Forbidden, PHPCompatibility.IniDirectives.RemovedIniDirectives.auto_detect_line_endingsDeprecated -- required for PHP 8.0 and earlier.
+		@ini_set( 'auto_detect_line_endings', true );
 	}
 
 	// open file pointer if $file is not a resource

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -27,5 +27,6 @@
 	<file>.</file>
 	<exclude-pattern>docs-built</exclude-pattern>
 	<exclude-pattern>node_modules</exclude-pattern>
+	<exclude-pattern>/tests</exclude-pattern>
 	<exclude-pattern>vendor</exclude-pattern>
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -6,6 +6,9 @@
 	<rule ref="WordPressVIPMinimum">
 		<!-- Caching warning is very out of date -->
 		<exclude name="WordPressVIPMinimum.Functions.RestrictedFunctions.get_posts_get_posts"/>
+
+		<!-- General purpose plugin, not used exclusively on VIP. -->
+		<exclude name="WordPressVIPMinimum.Classes.RestrictedExtendClasses.wp_cli"/>
 	</rule>
 
 	<rule ref="WordPress.Security.ValidatedSanitizedInput">

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,7 +1,15 @@
 <?xml version="1.0"?>
 <ruleset name="Project Rules">
-	<rule ref="10up-Default">
-	</rule>
+	<rule ref="WordPress-Core" />
+	<rule ref="WordPress.DB"/>
+	<rule ref="WordPress.Security"/>
+	<rule ref="WordPressVIPMinimum"/>
+
+	<arg name="extensions" value="php" />
+	<arg value="s"/>
+
+	<file>.</file>
+	<exclude-pattern>docs-built</exclude-pattern>
 	<exclude-pattern>node_modules</exclude-pattern>
 	<exclude-pattern>vendor</exclude-pattern>
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -5,6 +5,16 @@
 	<rule ref="WordPress.Security"/>
 	<rule ref="WordPressVIPMinimum"/>
 
+	<rule ref="WordPress.Security.ValidatedSanitizedInput">
+		<properties>
+			<property name="customSanitizingFunctions" type="array">
+				<element value="srm_sanitize_redirect_from"/>
+				<element value="srm_sanitize_redirect_to"/>
+			</property>
+		</properties>
+	</rule>
+
+
 	<arg name="extensions" value="php" />
 	<arg value="s"/>
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -3,7 +3,10 @@
 	<rule ref="WordPress-Core" />
 	<rule ref="WordPress.DB"/>
 	<rule ref="WordPress.Security"/>
-	<rule ref="WordPressVIPMinimum"/>
+	<rule ref="WordPressVIPMinimum">
+		<!-- Caching warning is very out of date -->
+		<exclude name="WordPressVIPMinimum.Functions.RestrictedFunctions.get_posts_get_posts"/>
+	</rule>
 
 	<rule ref="WordPress.Security.ValidatedSanitizedInput">
 		<properties>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -25,8 +25,8 @@
 	<arg value="s"/>
 
 	<file>.</file>
-	<exclude-pattern>docs-built</exclude-pattern>
-	<exclude-pattern>node_modules</exclude-pattern>
-	<exclude-pattern>/tests</exclude-pattern>
-	<exclude-pattern>vendor</exclude-pattern>
+	<exclude-pattern>*/docs-built/*</exclude-pattern>
+	<exclude-pattern>*/node_modules/*</exclude-pattern>
+	<exclude-pattern>*/tests/*</exclude-pattern>
+	<exclude-pattern>*/vendor/*</exclude-pattern>
 </ruleset>

--- a/safe-redirect-manager.php
+++ b/safe-redirect-manager.php
@@ -43,7 +43,7 @@ function site_meets_php_requirements(): bool {
 if ( ! site_meets_php_requirements() ) {
 	add_action(
 		'admin_notices',
-		function() {
+		function () {
 			?>
 			<div class="notice notice-error">
 				<p>
@@ -65,17 +65,17 @@ if ( ! site_meets_php_requirements() ) {
 }
 
 // Load helper functions and classes
-require_once dirname( __FILE__ ) . '/inc/functions.php';
-require_once dirname( __FILE__ ) . '/inc/classes/class-srm-post-type.php';
-require_once dirname( __FILE__ ) . '/inc/classes/class-srm-redirect.php';
-require_once dirname( __FILE__ ) . '/inc/classes/class-srm-loop-detection.php';
+require_once __DIR__ . '/inc/functions.php';
+require_once __DIR__ . '/inc/classes/class-srm-post-type.php';
+require_once __DIR__ . '/inc/classes/class-srm-redirect.php';
+require_once __DIR__ . '/inc/classes/class-srm-loop-detection.php';
 
 define( 'SRM_VERSION', '2.2.2' );
 define( 'SRM_PLUGIN_FULL_FILE', __FILE__ );
 define( 'SRM_PLUGIN_URL', plugin_dir_url( SRM_PLUGIN_FULL_FILE ) );
 
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
-	require_once dirname( __FILE__ ) . '/inc/classes/class-srm-wp-cli.php';
+	require_once __DIR__ . '/inc/classes/class-srm-wp-cli.php';
 	\WP_CLI::add_command( 'safe-redirect-manager', 'SRM_WP_CLI' );
 }
 

--- a/tests/php/test-core.php
+++ b/tests/php/test-core.php
@@ -19,11 +19,14 @@ class SRMTestCore extends WP_UnitTestCase {
 		srm_create_redirect( '/', $redirect_to );
 
 		add_action(
-			'srm_do_redirect', function( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
+			'srm_do_redirect',
+			function ( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
 				if ( $redirected_to === $redirect_to ) {
 					$redirected = true;
 				}
-			}, 10, 3
+			},
+			10,
+			3
 		);
 
 		SRM_Redirect::factory()->maybe_redirect();
@@ -43,11 +46,14 @@ class SRMTestCore extends WP_UnitTestCase {
 		srm_create_redirect( '/one/', $redirect_to );
 
 		add_action(
-			'srm_do_redirect', function( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
+			'srm_do_redirect',
+			function ( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
 				if ( $redirected_to === $redirect_to ) {
 					$redirected = true;
 				}
-			}, 10, 3
+			},
+			10,
+			3
 		);
 
 		SRM_Redirect::factory()->maybe_redirect();
@@ -60,11 +66,14 @@ class SRMTestCore extends WP_UnitTestCase {
 		srm_create_redirect( '/ONE/', $redirect_to );
 
 		add_action(
-			'srm_do_redirect', function( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
+			'srm_do_redirect',
+			function ( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
 				if ( $redirected_to === $redirect_to ) {
 					$redirected = true;
 				}
-			}, 10, 3
+			},
+			10,
+			3
 		);
 
 		SRM_Redirect::factory()->maybe_redirect();
@@ -84,17 +93,23 @@ class SRMTestCore extends WP_UnitTestCase {
 		srm_create_redirect( '/one/', $redirect_to );
 
 		add_filter(
-			'srm_case_insensitive_redirects', function( $value ) {
+			'srm_case_insensitive_redirects',
+			function ( $value ) {
 				return false;
-			}, 10, 1
+			},
+			10,
+			1
 		);
 
 		add_action(
-			'srm_do_redirect', function( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
+			'srm_do_redirect',
+			function ( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
 				if ( $redirected_to === $redirect_to ) {
 					$redirected = true;
 				}
-			}, 10, 3
+			},
+			10,
+			3
 		);
 
 		SRM_Redirect::factory()->maybe_redirect();
@@ -114,11 +129,14 @@ class SRMTestCore extends WP_UnitTestCase {
 		srm_create_redirect( '/one/', $redirect_to );
 
 		add_action(
-			'srm_do_redirect', function( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
+			'srm_do_redirect',
+			function ( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
 				if ( $redirected_to === $redirect_to ) {
 					$redirected = true;
 				}
-			}, 10, 3
+			},
+			10,
+			3
 		);
 
 		SRM_Redirect::factory()->maybe_redirect();
@@ -138,11 +156,14 @@ class SRMTestCore extends WP_UnitTestCase {
 		srm_create_redirect( '/one*', $redirect_to );
 
 		add_action(
-			'srm_do_redirect', function( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
+			'srm_do_redirect',
+			function ( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
 				if ( $redirected_to === $redirect_to ) {
 					$redirected = true;
 				}
-			}, 10, 3
+			},
+			10,
+			3
 		);
 
 		SRM_Redirect::factory()->maybe_redirect();
@@ -162,11 +183,14 @@ class SRMTestCore extends WP_UnitTestCase {
 		srm_create_redirect( '/one/*', $redirect_to );
 
 		add_action(
-			'srm_do_redirect', function( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
+			'srm_do_redirect',
+			function ( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
 				if ( $redirected_to === '/gohere/two' ) {
 					$redirected = true;
 				}
-			}, 10, 3
+			},
+			10,
+			3
 		);
 
 		SRM_Redirect::factory()->maybe_redirect();
@@ -190,11 +214,14 @@ class SRMTestCore extends WP_UnitTestCase {
 		srm_create_redirect( '/one/', $redirect_to );
 
 		add_action(
-			'srm_do_redirect', function( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
+			'srm_do_redirect',
+			function ( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
 				if ( $redirected_to === $redirect_to ) {
 					$redirected = true;
 				}
-			}, 10, 3
+			},
+			10,
+			3
 		);
 
 		SRM_Redirect::factory()->maybe_redirect();
@@ -207,11 +234,14 @@ class SRMTestCore extends WP_UnitTestCase {
 		srm_create_redirect( '/one', $redirect_to );
 
 		add_action(
-			'srm_do_redirect', function( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
+			'srm_do_redirect',
+			function ( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
 				if ( $redirected_to === $redirect_to ) {
 					$redirected = true;
 				}
-			}, 10, 3
+			},
+			10,
+			3
 		);
 
 		SRM_Redirect::factory()->maybe_redirect();
@@ -224,11 +254,14 @@ class SRMTestCore extends WP_UnitTestCase {
 		srm_create_redirect( '/one/two/', $redirect_to );
 
 		add_action(
-			'srm_do_redirect', function( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
+			'srm_do_redirect',
+			function ( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
 				if ( $redirected_to === $redirect_to ) {
 					$redirected = true;
 				}
-			}, 10, 3
+			},
+			10,
+			3
 		);
 
 		SRM_Redirect::factory()->maybe_redirect();
@@ -241,11 +274,14 @@ class SRMTestCore extends WP_UnitTestCase {
 		srm_create_redirect( '/one/two', $redirect_to );
 
 		add_action(
-			'srm_do_redirect', function( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
+			'srm_do_redirect',
+			function ( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
 				if ( $redirected_to === $redirect_to ) {
 					$redirected = true;
 				}
-			}, 10, 3
+			},
+			10,
+			3
 		);
 
 		SRM_Redirect::factory()->maybe_redirect();
@@ -262,11 +298,14 @@ class SRMTestCore extends WP_UnitTestCase {
 		srm_create_redirect( '/.*/', $redirect_to, 301, true );
 
 		add_action(
-			'srm_do_redirect', function( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
+			'srm_do_redirect',
+			function ( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
 				if ( $redirected_to === $redirect_to ) {
 					$redirected = true;
 				}
-			}, 10, 3
+			},
+			10,
+			3
 		);
 
 		SRM_Redirect::factory()->maybe_redirect();
@@ -279,11 +318,14 @@ class SRMTestCore extends WP_UnitTestCase {
 		srm_create_redirect( '/.*', $redirect_to, 301, true );
 
 		add_action(
-			'srm_do_redirect', function( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
+			'srm_do_redirect',
+			function ( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
 				if ( $redirected_to === $redirect_to ) {
 					$redirected = true;
 				}
-			}, 10, 3
+			},
+			10,
+			3
 		);
 
 		SRM_Redirect::factory()->maybe_redirect();
@@ -303,11 +345,14 @@ class SRMTestCore extends WP_UnitTestCase {
 		srm_create_redirect( '/test', $redirect_to );
 
 		add_action(
-			'srm_do_redirect', function( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
+			'srm_do_redirect',
+			function ( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
 				if ( $redirected_to === $redirect_to ) {
 					$redirected = true;
 				}
-			}, 10, 3
+			},
+			10,
+			3
 		);
 
 		SRM_Redirect::factory()->maybe_redirect();
@@ -324,11 +369,14 @@ class SRMTestCore extends WP_UnitTestCase {
 		srm_create_redirect( '/test/this/path/', $redirect_to );
 
 		add_action(
-			'srm_do_redirect', function( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
+			'srm_do_redirect',
+			function ( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
 				if ( $redirected_to === $redirect_to ) {
 					$redirected = true;
 				}
-			}, 10, 3
+			},
+			10,
+			3
 		);
 
 		SRM_Redirect::factory()->maybe_redirect();
@@ -345,11 +393,14 @@ class SRMTestCore extends WP_UnitTestCase {
 		srm_create_redirect( '/test/right/path/', $redirect_to );
 
 		add_action(
-			'srm_do_redirect', function( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
+			'srm_do_redirect',
+			function ( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
 				if ( $redirected_to === $redirect_to ) {
 					$redirected = true;
 				}
-			}, 10, 3
+			},
+			10,
+			3
 		);
 
 		SRM_Redirect::factory()->maybe_redirect();
@@ -369,11 +420,14 @@ class SRMTestCore extends WP_UnitTestCase {
 		srm_create_redirect( '/tes?t/[0-9]+/path/[^/]+/?', $redirect_to, 301, true );
 
 		add_action(
-			'srm_do_redirect', function( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
+			'srm_do_redirect',
+			function ( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
 				if ( $redirected_to === $redirect_to ) {
 					$redirected = true;
 				}
-			}, 10, 3
+			},
+			10,
+			3
 		);
 
 		SRM_Redirect::factory()->maybe_redirect();
@@ -390,11 +444,14 @@ class SRMTestCore extends WP_UnitTestCase {
 		srm_create_redirect( '/([a-z]+)/.*', $redirect_to, 301, true );
 
 		add_action(
-			'srm_do_redirect', function( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
+			'srm_do_redirect',
+			function ( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
 				if ( $redirected_to === '/well' ) {
 					$redirected = true;
 				}
-			}, 10, 3
+			},
+			10,
+			3
 		);
 
 		SRM_Redirect::factory()->maybe_redirect();
@@ -411,11 +468,14 @@ class SRMTestCore extends WP_UnitTestCase {
 		srm_create_redirect( '/[0-9]+', $redirect_to, 301, true );
 
 		add_action(
-			'srm_do_redirect', function( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
+			'srm_do_redirect',
+			function ( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
 				if ( $redirected_to === $redirect_to ) {
 					$redirected = true;
 				}
-			}, 10, 3
+			},
+			10,
+			3
 		);
 
 		SRM_Redirect::factory()->maybe_redirect();
@@ -436,11 +496,14 @@ class SRMTestCore extends WP_UnitTestCase {
 		srm_create_redirect( '/myfiles1/*', $redirect_to );
 
 		add_action(
-			'srm_do_redirect', function( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
+			'srm_do_redirect',
+			function ( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
 				if ( $redirected_to === '/images1/FooBar.JPEG' ) {
 					$redirected = true;
 				}
-			}, 10, 3
+			},
+			10,
+			3
 		);
 
 		SRM_Redirect::factory()->maybe_redirect();
@@ -454,11 +517,14 @@ class SRMTestCore extends WP_UnitTestCase {
 		srm_create_redirect( '/myfiles2/(.*\.jpe?g)', $redirect_to, 301, true );
 
 		add_action(
-			'srm_do_redirect', function( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
+			'srm_do_redirect',
+			function ( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
 				if ( $redirected_to === '/images2/FooBar.JPEG' ) {
 					$redirected = true;
 				}
-			}, 10, 3
+			},
+			10,
+			3
 		);
 
 		SRM_Redirect::factory()->maybe_redirect();
@@ -493,7 +559,8 @@ class SRMTestCore extends WP_UnitTestCase {
 		// let's import it
 		fseek( $tmp_file, 0 );
 		$processed = srm_import_file(
-			$tmp_file, array(
+			$tmp_file,
+			array(
 				'source' => 'legacy url',
 				'target' => 'new url',
 				'regex'  => 'is_regex',
@@ -518,15 +585,15 @@ class SRMTestCore extends WP_UnitTestCase {
 	 */
 	public function testWildcardRedirectWithSlash() {
 		$_SERVER['REQUEST_URI'] = '/one/';
-		$redirected			    = false;
-		$redirect_to			= '/gohere/';
+		$redirected             = false;
+		$redirect_to            = '/gohere/';
 
 		// Create two redirects for testing.
 		srm_create_redirect( '/one/*', $redirect_to );
 		srm_create_redirect( '/two/', $redirect_to );
 		add_action(
 			'srm_do_redirect',
-			function( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
+			function ( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected ) {
 				if ( $redirected_to === $redirect_to ) {
 					$redirected = true;
 				}
@@ -552,7 +619,7 @@ class SRMTestCore extends WP_UnitTestCase {
 		$expected = '/gohere/?test=true';
 		add_action(
 			'srm_do_redirect',
-			function( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected, &$expected ) {
+			function ( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected, &$expected ) {
 				if ( $redirected_to === '/gohere/?test=true' ) {
 					$redirected = true;
 				}
@@ -577,7 +644,7 @@ class SRMTestCore extends WP_UnitTestCase {
 		srm_create_redirect( '/one/*', $redirect_to );
 		add_action(
 			'srm_do_redirect',
-			function() use ( &$redirected ) {
+			function () use ( &$redirected ) {
 				$redirected = true;
 			},
 			10,
@@ -601,7 +668,7 @@ class SRMTestCore extends WP_UnitTestCase {
 		srm_create_redirect( '/two/', $redirect_to );
 		add_action(
 			'srm_do_redirect',
-			function( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected, &$expected ) {
+			function ( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected, &$expected ) {
 					$redirected = true;
 			},
 			10,
@@ -616,7 +683,7 @@ class SRMTestCore extends WP_UnitTestCase {
 	 *
 	 */
 	public function testMatchRedirect() {
-		$redirect_to            = '/gohere';
+		$redirect_to = '/gohere';
 		srm_create_redirect( '/', $redirect_to );
 
 		$matched_redirect = srm_match_redirect( '/' );
@@ -642,7 +709,7 @@ class SRMTestCore extends WP_UnitTestCase {
 		$expected = '/gohere/?test=true';
 		add_action(
 			'srm_do_redirect',
-			function( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected, &$expected ) {
+			function ( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected, &$expected ) {
 				if ( $redirected_to === '/gohere/?test=true' ) {
 					$redirected = true;
 				}
@@ -664,12 +731,12 @@ class SRMTestCore extends WP_UnitTestCase {
 		$redirected             = false;
 		$redirect_to            = '/gohere/';
 
-		add_filter('srm_match_query_params', '__return_true');
+		add_filter( 'srm_match_query_params', '__return_true' );
 
 		srm_create_redirect( '/one/', $redirect_to );
 		add_action(
 			'srm_do_redirect',
-			function( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected, &$expected ) {
+			function ( $requested_path, $redirected_to, $status_code ) use ( &$redirect_to, &$redirected, &$expected ) {
 				$redirected = true;
 			},
 			10,
@@ -679,7 +746,7 @@ class SRMTestCore extends WP_UnitTestCase {
 		SRM_Redirect::factory()->maybe_redirect();
 		$this->assertFalse( $redirected, 'Expected that /noredirect/ would not redirect, but instead redirected to ' . $redirect_to );
 
-		remove_filter('srm_match_query_params', '__return_true');
+		remove_filter( 'srm_match_query_params', '__return_true' );
 	}
 
 	/**
@@ -706,7 +773,7 @@ class SRMTestCore extends WP_UnitTestCase {
 
 		add_action(
 			'srm_do_redirect',
-			function( $requested_path, $redirected_to, $status_code ) use ( &$actual_request, &$actual_redirect, &$actual_status ) {
+			function ( $requested_path, $redirected_to, $status_code ) use ( &$actual_request, &$actual_redirect, &$actual_status ) {
 				$actual_request  = $requested_path;
 				$actual_redirect = $redirected_to;
 				$actual_status   = $status_code;
@@ -745,7 +812,7 @@ class SRMTestCore extends WP_UnitTestCase {
 
 		add_action(
 			'srm_do_redirect',
-			function( $requested_path, $redirected_to, $status_code ) use ( &$actual_request, &$actual_redirect, &$actual_status ) {
+			function ( $requested_path, $redirected_to, $status_code ) use ( &$actual_request, &$actual_redirect, &$actual_status ) {
 				$actual_request  = $requested_path;
 				$actual_redirect = $redirected_to;
 				$actual_status   = $status_code;
@@ -784,7 +851,7 @@ class SRMTestCore extends WP_UnitTestCase {
 
 		add_action(
 			'srm_do_redirect',
-			function( $requested_path, $redirected_to, $status_code ) use ( &$actual_request, &$actual_redirect, &$actual_status ) {
+			function ( $requested_path, $redirected_to, $status_code ) use ( &$actual_request, &$actual_redirect, &$actual_status ) {
 				$actual_request  = $requested_path;
 				$actual_redirect = $redirected_to;
 				$actual_status   = $status_code;


### PR DESCRIPTION
### Description of the Change

Switch to following WordPress Coding Standards for WP.org hosted plugin.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #448 

### How to test the Change

Ensure tests pass.

Follow critical flow tests.

**Key commits for reviewing**

* b45f7b0469dd84cef1190a8a6779eda65501e707 : Refactor of `is_plugin_page()` method.
* d9f58ec7b3552ba2b062f821cb750c6dc40dbec2 : Refactor autocomplete render


### Changelog Entry
> Developer - Updated to follow WordPress Coding Standards.

### Credits
Props @peterwilsoncc 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
