### PR TITLE
Add Plugin Check Workflow

### DIFF
--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -35,3 +35,4 @@ jobs:
         uses: wordpress/plugin-check-action@6f5a57e173c065a394b78688f75df543e4011902 # v1.1.5
         with:
           build-dir: './tmp-build/safe-redirect-manager'
+          ignore-codes: 'WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound,WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound'

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: write
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -37,4 +37,4 @@ jobs:
           build-dir: './tmp-build/safe-redirect-manager'
           # Prefix: Plugin uses `srm_` as the prefix rather than the full plugin name. It was submitted to wp.org 14 years ago.
           # InputNotSanitized: Tested by phpcs workflow. Fails in plugin check due to custom sanitization functions.
-          ignore-codes: 'WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound,WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized'
+          ignore-codes: 'WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound,WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,Squiz.PHP.DiscouragedFunctions.Discouraged'

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -1,0 +1,36 @@
+name: Plugin Check
+
+on:
+  push:
+    branches:
+      - develop
+      - trunk
+  pull_request:
+    branches:
+      - develop
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
+jobs:
+  plugin-check:
+    name: Run Plugin Check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Export to temporary directory
+        run: |
+          mkdir -p tmp-build/safe-redirect-manager
+          git archive HEAD -o safe-redirect-manager.zip
+          unzip safe-redirect-manager.zip -d tmp-build/safe-redirect-manager
+
+      - name: Run plugin check
+        uses: wordpress/plugin-check-action@6f5a57e173c065a394b78688f75df543e4011902 # v1.1.5
+        with:
+          build-dir: './tmp-build/safe-redirect-manager'

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -35,4 +35,6 @@ jobs:
         uses: wordpress/plugin-check-action@6f5a57e173c065a394b78688f75df543e4011902 # v1.1.5
         with:
           build-dir: './tmp-build/safe-redirect-manager'
+          # Prefix: Plugin uses `srm_` as the prefix rather than the full plugin name. It was submitted to wp.org 14 years ago.
+          # InputNotSanitized: Tested by phpcs workflow. Fails in plugin check due to custom sanitization functions.
           ignore-codes: 'WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound,WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized'

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -35,4 +35,4 @@ jobs:
         uses: wordpress/plugin-check-action@6f5a57e173c065a394b78688f75df543e4011902 # v1.1.5
         with:
           build-dir: './tmp-build/safe-redirect-manager'
-          ignore-codes: 'WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound,WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound'
+          ignore-codes: 'WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound,WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized'

--- a/inc/classes/class-srm-loop-detection.php
+++ b/inc/classes/class-srm-loop-detection.php
@@ -5,6 +5,10 @@
  * @package safe-redirect-manager
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Run in WP context only.
+}
+
 /**
  * Class for redirect loop detection.
  */

--- a/inc/classes/class-srm-post-type.php
+++ b/inc/classes/class-srm-post-type.php
@@ -5,6 +5,10 @@
  * @package safe-redirect-manager
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Run in WP context only.
+}
+
 /**
  * Post type class
  */

--- a/inc/classes/class-srm-redirect.php
+++ b/inc/classes/class-srm-redirect.php
@@ -5,6 +5,10 @@
  * @package safe-redirect-manager
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Run in WP context only.
+}
+
 /**
  * Redirect functionality class
  */

--- a/inc/classes/class-srm-wp-cli.php
+++ b/inc/classes/class-srm-wp-cli.php
@@ -7,6 +7,10 @@
 
 use WP_CLI\Utils;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Run in WP context only.
+}
+
 /**
  * WP CLI command class
  */

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -5,6 +5,10 @@
  * @package safe-redirect-manager
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Run in WP context only.
+}
+
 /**
  * Get redirects from the database
  *

--- a/safe-redirect-manager.php
+++ b/safe-redirect-manager.php
@@ -17,6 +17,10 @@
 
 namespace SafeRedirectManager;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Run in WP context only.
+}
+
 /**
  * Get the minimum version of PHP required by this plugin.
  *


### PR DESCRIPTION
### Description of the Change

Adds the [WordPress Plugin Check workflow](https://github.com/WordPress/plugin-check-action).

There are a lot of warnings showing for the prefix `srm_` rather than `safe_redirect_manager_`. It would have been flagged in a more recent submission but 14 years ago when the plugin was submitted it was accepted.

I can't see a way of setting the plugin check to accept srm as a prefix.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #450 

### How to test the Change

Review plugin workflow and ensure it passes.


### Changelog Entry
> Developer - Add WordPress Plugin Check workflow.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @peterwilsoncc

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
